### PR TITLE
Remove points from Camera, althought remember last set of framing points

### DIFF
--- a/src/meshsee/render/renderer.py
+++ b/src/meshsee/render/renderer.py
@@ -184,10 +184,10 @@ class Renderer:
             self._camera.view_matrix,
         )
         self._main_renderee.subscribe_to_updates(self.on_program_value_change)
-        self._camera.points = self._main_renderee.points
+        self._framing_points = self._main_renderee.points
 
     def frame(self, direction=None, up=None):
-        self._camera.frame(direction, up)
+        self._camera.frame(self._framing_points, direction, up)
 
     def orbit(self, angle_from_up, rotation_angle):
         self._camera.orbit(angle_from_up, rotation_angle)

--- a/tests/render/test_camera.py
+++ b/tests/render/test_camera.py
@@ -336,8 +336,8 @@ def test_fovx_aspect_ratio_not_1():
 
 def test_frame_centered():
     cam = Camera()
-    cam.points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    cam.frame(np.array([3.0, 2.0, 1.0]))
+    points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    cam.frame(points, np.array([3.0, 2.0, 1.0]))
     assert np.array_equal(np.array([2.5, 3.5, 4.5]), cam.look_at)
 
 
@@ -345,8 +345,8 @@ def test_frame_direction_same():
     cam = Camera()
     dir = np.array([3.0, 2.0, 1.0])
     norm_dir = dir / np.linalg.norm(dir)
-    cam.points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    cam.frame(np.array([3.0, 2.0, 1.0]))
+    points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    cam.frame(points, np.array([3.0, 2.0, 1.0]))
     assert np.allclose(norm_dir, cam.direction / np.linalg.norm(cam.direction))
 
 
@@ -355,8 +355,8 @@ def test_frame_use_cam_direction():
     cam.look_at = np.array([1.0, -2.0, 3.0])
     cam.position = np.array([4.0, 5.0, -6.0])
     init_direction = cam.direction
-    cam.points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    cam.frame()
+    points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    cam.frame(points)
     assert init_direction / np.linalg.norm(init_direction) == approx(
         cam.direction / np.linalg.norm(cam.direction)
     )
@@ -367,8 +367,8 @@ def test_frame_use_cam_up():
     cam.look_at = np.array([1.0, -2.0, 3.0])
     cam.position = np.array([4.0, 5.0, -6.0])
     init_up = cam.up
-    cam.points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    cam.frame(np.array([3.0, 2.0, 1.0]))
+    points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    cam.frame(points, np.array([3.0, 2.0, 1.0]))
     assert init_up / np.linalg.norm(init_up) == approx(cam.up / np.linalg.norm(cam.up))
 
 
@@ -377,8 +377,8 @@ def test_frame_override_cam_up():
     cam.look_at = np.array([1.0, -2.0, 3.0])
     cam.position = np.array([4.0, 5.0, -6.0])
     init_up = np.array([1.0, 1.0, 1.0])
-    cam.points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    cam.frame(np.array([3.0, 2.0, 1.0]), init_up)
+    points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    cam.frame(points, np.array([3.0, 2.0, 1.0]), init_up)
     assert init_up / np.linalg.norm(init_up) == approx(cam.up / np.linalg.norm(cam.up))
 
 
@@ -412,8 +412,7 @@ def check_frame_points_in_clip(multiplier):
     )
     # fmt on
     direction = np.array([3.0, 2.0, 1.0])
-    cam.points = points
-    cam.frame(direction)
+    cam.frame(points, direction)
     print(f"fovx: {cam.fovx}; fovy: {cam.fovy}")
 
     # cam should be pointing along direction

--- a/tests/render/test_renderer.py
+++ b/tests/render/test_renderer.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
+import numpy as np
+
 from meshsee.render.camera import Camera
 from meshsee.render.renderer import Renderer
 
@@ -34,5 +36,5 @@ def test_frame():
     with patch("meshsee.render.shader_program.isinstance") as mock_isinstance:
         mock_isinstance.return_value = True
         renderer = Renderer(context, camera, aspect_ratio)
-        renderer.frame()
+        renderer.frame(np.array([[1, 0, 0]]))
         camera.frame.assert_called()


### PR DESCRIPTION
Keeping the framining points in the Camera class seemed out of place.  So I pass in points on the frame() call.  I retain the last copy of the points for recalculating near/far planes when the camera moves.