### PR TITLE
Example: add name along tube length with a base plate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ wheels/
 
 # model files
 **/*.stl
+**/*.3mf
 
 # documetation build
 site/

--- a/examples/toothbrush_holder.py
+++ b/examples/toothbrush_holder.py
@@ -37,7 +37,8 @@ HEX_GRID_COLS = 8  # Count of cols in the hex grid that makes the tube
 GRID_DIV_WIDTH = 1.5  # Thickeness of the divisions between the hex cells
 
 POSITIONING_R = (
-    28  # Radius of the circle on which the tubes tops / bottoms are positioned
+    28  # Radius of the circle on which the center of the tubes tops / bottoms are positioned
+    # If the tubes intersect too deeply, increase this.
 )
 # Radius of the circle the center of the tubes are positioned on
 # (position_r)**2  = center_positioning_r**2  + (sin(tilt) * tube_h / 2)**2
@@ -48,9 +49,10 @@ CENTER_POSITIONING_R = np.sqrt(
 FONT = "Helvetica"  # Font for names
 FONT_H = TUBE_WALL  # Extruded height of the font
 FONT_SIZE = 8  # font "size"
-NAME_BASE_H = TUBE_WALL  # Height of base under name
+NAME_PLATE_H = 3  # Height of base under name
+NAME_PLATE_BORDER = 2
 
-BASE_R = 41  # Radius of the base
+BASE_R = 41  # Radius of the base - make large enough so that the tube bottom ends are completely embedded in the base
 BASE_H = 5  # Height (thickness) of the base
 
 
@@ -60,7 +62,7 @@ def create_mesh() -> (
     hex_grid = make_grid(TUBE_INNER_R, TUBE_H, TUBE_WALL, HEX_GRID_COLS, GRID_DIV_WIDTH)
     yield hex_grid
 
-    # Each tube is moved radially in evenly spaced directions around the circle
+    # Each tube is moved radially in evenly spaced directions around a full circle
     tube_move_directions = np.linspace(0.0, 2 * np.pi, len(NAMES) + 1)
     mesh = Trimesh()  # Keep the type checking happy
     mesh_started = False
@@ -74,28 +76,11 @@ def create_mesh() -> (
         ).apply_scale([1, 1, FONT_H])
         yield name_mesh
 
-        # name_frame_dims = name_mesh.bounds[1] - name_mesh.bounds[0] + [0, 2, 0]
-        # name_frame_dims[0] = hex_grid.bounds[1, 0] - hex_grid.bounds[0, 0]
-        # name_frame = box(name_frame_dims).apply_translation(
-        #     (0, name_frame_dims[1] / 2, -name_frame_dims[2] / 2)
-        # )
-        # name_mesh = name_frame.difference(name_mesh)
-
-        # name_base_dims = name_mesh.bounds[1] - name_mesh.bounds[0]
-        # name_base_dims[1] = NAME_BASE_H
-        # name_base = box(name_base_dims).apply_translation(
-        #     (0, -name_base_dims[1] / 2, -name_base_dims[2] / 2)
-        # )
-        # name_mesh = name_mesh.union(name_base)
-
         grid_mesh = add_name(
             hex_grid.copy(),
-            TUBE_INNER_R,
-            TUBE_H,
-            TUBE_WALL,
-            HEX_GRID_COLS,
-            GRID_DIV_WIDTH,
             name_mesh,
+            NAME_PLATE_H,
+            NAME_PLATE_BORDER,
         )
         yield grid_mesh
 
@@ -171,42 +156,26 @@ def hex_cell_dims_for_tube(
 
 def add_name(
     grid_mesh: Trimesh,
-    tube_inner_r: float,
-    tube_h: float,
-    tube_wall: float,
-    grid_cols: int,
-    grid_div_width: float,
     name_mesh: Trimesh,
+    name_plate_h: float,
+    name_plate_border: float,
 ) -> Trimesh:
     """
-    Place name at top of grid, standing up at 90 degrees
+    Place name so that it will run vertically along the tube.
+    Add a plate behind it.
     """
-    # hex_cell_dims, rows = hex_cell_dims_for_tube(
-    #     tube_inner_r,
-    #     tube_h,
-    #     tube_wall,
-    #     grid_div_width,
-    #     grid_cols,
-    # )
-    # frame_dims = hex_grid_dims(hex_cell_dims, grid_cols, rows)
-    # name_mesh.apply_transform(
-    #     transformations.rotation_matrix(np.pi, [0, 1, 0], [0, 0, 0])
-    # )
-    # name_mesh.apply_transform(
-    #     transformations.rotation_matrix(np.pi / 2, [1, 0, 0], [0, 0, 0])
-    # )
-    # name_mesh.apply_translation(
-    #     (frame_dims[0] / 2, frame_dims[1] + grid_div_width, frame_dims[2])
-    # )
-    #
     name_mesh_dims = name_mesh.bounds[1] - name_mesh.bounds[0]
-    base_dims = [name_mesh_dims[0] + 2, name_mesh_dims[1] + 4, tube_wall]
+    base_dims = [
+        name_mesh_dims[0] + name_plate_border,  # Only add the border at end of name
+        # Add border on top and bottom of name:
+        name_mesh_dims[1] + name_plate_border * 2,
+        name_plate_h,
+    ]
     base = box(base_dims).apply_translation(
-        (2, base_dims[1] / 2 - 2, -base_dims[2] / 2)
+        (2, base_dims[1] / 2 - name_plate_border, -base_dims[2] / 2)
     )
     name_mesh = name_mesh.union(base)
-    name_mesh.apply_translation((name_mesh_dims[0] / 2, 0, tube_wall))
-    # name_base = box((name_base_dims))
+    name_mesh.apply_translation((name_mesh_dims[0] / 2, 0, name_plate_h))
     name_mesh.apply_transform(
         transformations.rotation_matrix(-np.pi / 2, [0, 0, 1], [0, 0, 0])
     )


### PR DESCRIPTION
Adds the name at the top of the tube, running along the length of the tube starting at the top edge.  A base plate is added for better readability.