### PR TITLE
Add debug flag; enable using in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ help:
 	@echo "            	This creates the virtual environment if it does not already exist"
 	@echo "The following require you have run make shell first"
 	@echo "  test    	- Run tests"
-	@echo "  run     	- Run the application"
+	@echo "  run 		- Run the application"
+	@echo "  			  Set the ARGS env var or param to pass args eg make run ARGS=-vv"
+	@echo "  			  make run ARGS=--help for more info"
 	@echo "  format  	- Format the code"
 	@echo "  lint    	- Lint the code"
 	@echo "  type		- Type check the code"
@@ -43,7 +45,7 @@ test: check-venv
 
 run: check-venv
 	@echo "Running the application..."
-	@python -m meshsee
+	@python -m meshsee $(ARGS)
 
 format: check-venv
 	@echo "Formatting the code..."

--- a/src/meshsee/app.py
+++ b/src/meshsee/app.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 
 from meshsee.controller import Controller
@@ -12,9 +13,41 @@ logger = logging.getLogger(__name__)
 
 
 def main():
+    set_logging_level()
     logger.info("Meshee app starting up")
     renderer_factory = RendererFactory(CameraPerspective())
     gl_widget_adapter = GlWidgetAdapter(renderer_factory)
     controller = Controller()
     GlUi(controller, gl_widget_adapter).run()
     logger.info("Meshee app stopping")
+
+
+def set_logging_level():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity (-v=INFO, -vv=DEBUG)",
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level directly",
+    )
+
+    args = parser.parse_args()
+
+    if args.log_level:
+        level = getattr(logging, args.log_level)
+    elif args.verbose == 1:
+        level = logging.INFO
+    elif args.verbose >= 2:
+        level = logging.DEBUG
+    else:
+        level = logging.WARNING
+
+    logger = logging.getLogger()
+    logger.warning(f"Setting debug to {level} ({logging.getLevelName(level)})")
+    logger.setLevel(level=level)

--- a/src/meshsee/controller.py
+++ b/src/meshsee/controller.py
@@ -50,16 +50,12 @@ class Controller:
             self._last_module_path = module_path
         logger.info(f"Starting load of {module_path}")
         t0 = time()
-        try:
-            for i, mesh in enumerate(self._module_loader.run_function(module_path)):
-                self.current_mesh = mesh
-                logger.info(f"Loading mesh #{i + 1}")
-                yield mesh
-            t1 = time()
-            logger.info(f"Load {module_path} took {(t1 - t0) * 1000:.1f}ms")
-        except Exception as e:
-            logger.exception(f"Error while loading {module_path}: {e}")
-            raise e
+        for i, mesh in enumerate(self._module_loader.run_function(module_path)):
+            self.current_mesh = mesh
+            logger.info(f"Loading mesh #{i + 1}")
+            yield mesh
+        t1 = time()
+        logger.info(f"Load {module_path} took {(t1 - t0) * 1000:.1f}ms")
 
     def export(self, file_path: str):
         if not self.current_mesh:


### PR DESCRIPTION
Add debug flags to the command line, and enable passing to make.
Remove redundant error log / exception when loading a script with errors.