### PR TITLE
Fix/linear extrude

### DIFF
--- a/src/meshsee/api/linear_extrude.py
+++ b/src/meshsee/api/linear_extrude.py
@@ -2,7 +2,6 @@ from enum import Enum, auto
 
 import numpy as np
 import shapely.geometry as sg
-import shapely.ops as so
 import trimesh
 from numpy.typing import NDArray
 from scipy.spatial import KDTree
@@ -99,14 +98,12 @@ def _is_list_2dim_2d_or_3d_points(profile: ProfileType) -> bool:
         isinstance(profile, list)
         and len(profile) > 0
         and (
-            (
-                all(
-                    [
-                        isinstance(vert, (tuple, list))  # type: ignore[reportUnecessaryIsInstance] - want to report to user if incorrect type
-                        and len(vert) in (2, 3)
-                        for vert in profile
-                    ]
-                )
+            all(
+                [
+                    isinstance(vert, (tuple, list))  # type: ignore[reportUnecessaryIsInstance] - want to report to user if incorrect type
+                    and len(vert) in (2, 3)
+                    for vert in profile
+                ]
             )
         )
     )
@@ -198,7 +195,6 @@ def _build_layers(
     final_scale: tuple[float, float],
     centroid: sg.Point,
 ) -> NDArray[np.float32]:
-
     # botttom layer
     verts_3d = np.column_stack((verts_2d, np.zeros(len(verts_2d)))).astype(np.float32)
 

--- a/tests/api/test_linear_extrude.py
+++ b/tests/api/test_linear_extrude.py
@@ -58,7 +58,7 @@ def _bounds_z(mesh: trimesh.Trimesh):
     "prof",
     [
         (_rect_xy(2.0, 1.0)),
-        ((_rect_xyz())),
+        (_rect_xyz()),
         (_rect_xy_list()),
         (_rect_xyz_list()),
         (sg.Polygon(_rect_xy(2.0, 1.0))),


### PR DESCRIPTION
This is a redo of linear_extrude; the previous one did not return a "volume", which meant that boolean operations would fail.  This version borrows heavily from the previous but:
- It has been refactored for readability
- Only the "ring" vertices are added to each layer as it is extruded
   - "ring" vertices are those that are in the original polygon, which may include holes (eg in a flat washer shape)
   - Exception: the top and bottom layers are the original polygon triangulated

