### PR TITLE
Slope letters so top face is narrower than bottom for better lighting

### DIFF
--- a/examples/xyz_cube.py
+++ b/examples/xyz_cube.py
@@ -34,9 +34,7 @@ def create_mesh():
         create_from_axis_rotation((1, 0, 0), np.pi / 2)
     ).apply_transform(
         create_from_axis_rotation((0, 0, 1), np.pi / 2)
-    ).apply_translation(
-        (SIZE / 2, 0, 0)
-    )
+    ).apply_translation((SIZE / 2, 0, 0))
     xy_center_mesh(y_mesh)
     y_mesh.apply_transform(
         create_from_axis_rotation((1, 0, 0), np.pi / 2)


### PR DESCRIPTION
With the letters having the bottom face the same size of the top face, viewing from the X+, Y+ and Z+ directions made the letters disappear due to the lighting.  By making the top face smaller, the sloped sides are visible and the letter can be made out.