### PR TITLE
Add progress guage

### DIFF
--- a/src/meshsee/ui/wx/main_frame.py
+++ b/src/meshsee/ui/wx/main_frame.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 LOAD_CHECK_INTERVAL_MS = 10
 INITIAL_FRAME_SIZE = (900, 600)
+BORDER_SIZE = 6
 
 
 class MainFrame(wx.Frame):
@@ -36,7 +37,7 @@ class MainFrame(wx.Frame):
             self._button_panel, style=wx.GA_HORIZONTAL | wx.GA_SMOOTH | wx.GA_PROGRESS
         )
         self._panel_sizer.Add(
-            self._load_progress_gauge, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 12
+            self._load_progress_gauge, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, BORDER_SIZE
         )
 
         self._add_file_buttons()
@@ -45,8 +46,12 @@ class MainFrame(wx.Frame):
         self._panel_sizer.AddStretchSpacer()
 
         root = wx.BoxSizer(wx.HORIZONTAL)
-        root.Add(self._gl_widget, 1, wx.EXPAND | wx.ALL, 6)
-        root.Add(self._panel_sizer, 0, wx.EXPAND | wx.ALL, 6)
+        root.Add(
+            self._gl_widget,
+            1,
+            wx.EXPAND | wx.ALL,
+        )
+        root.Add(self._panel_sizer, 0, wx.EXPAND | wx.ALL, BORDER_SIZE)
         self._button_panel.SetSizer(root)
 
         menu_bar = wx.MenuBar()
@@ -121,11 +126,11 @@ class MainFrame(wx.Frame):
 
     def _add_file_buttons(self):
         load_btn = self._load_action.button(self._button_panel)
-        self._panel_sizer.Add(load_btn, 0, wx.ALL | wx.EXPAND, 6)
+        self._panel_sizer.Add(load_btn, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
         self._reload_btn = self._reload_action.button(self._button_panel)
-        self._panel_sizer.Add(self._reload_btn, 0, wx.ALL | wx.EXPAND, 6)
+        self._panel_sizer.Add(self._reload_btn, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
         self._export_btn = self._export_action.button(self._button_panel)
-        self._panel_sizer.Add(self._export_btn, 0, wx.ALL | wx.EXPAND, 6)
+        self._panel_sizer.Add(self._export_btn, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
 
     def _on_module_path_set(self, path: str) -> bool:
         return path != ""
@@ -142,13 +147,13 @@ class MainFrame(wx.Frame):
             self._view_from_z_action,
         ]:
             btn = action.button(self._button_panel)
-            self._panel_sizer.Add(btn, 0, wx.ALL | wx.EXPAND, 6)
+            self._panel_sizer.Add(btn, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
 
         chk = self._toggle_grid_action.checkbox(self._button_panel)
-        self._panel_sizer.Add(chk, 0, wx.ALL | wx.EXPAND, 6)
+        self._panel_sizer.Add(chk, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
 
         for rb in self._select_camera_action.radio_buttons(self._button_panel):
-            self._panel_sizer.Add(rb, 0, wx.ALL | wx.EXPAND, 6)
+            self._panel_sizer.Add(rb, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
 
         for action in [
             self._toggle_axes_action,
@@ -156,7 +161,7 @@ class MainFrame(wx.Frame):
             self._toggle_gnonom_action,
         ]:
             chk = action.checkbox(self._button_panel)
-            self._panel_sizer.Add(chk, 0, wx.ALL | wx.EXPAND, 6)
+            self._panel_sizer.Add(chk, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
 
     def _create_file_menu(self) -> wx.Menu:
         file_menu = wx.Menu()


### PR DESCRIPTION
Adds a progress gauge to the top of the panel.  This is run in "indeterminant" mode, since we don't know in advance how long the mesh will take to load.

