### PR TITLE
Feat/wx fix screen coords

### DIFF
--- a/src/meshsee/ui/wx/gl_widget.py
+++ b/src/meshsee/ui/wx/gl_widget.py
@@ -120,16 +120,6 @@ class GlWidget(GLCanvas):
             self._mouse_captured = True
         self._gl_widget_adapter.start_orbit(int(pos.x), int(pos.y))
 
-    def _get_scaled_position(self, event: wx.MouseEvent) -> wx.Point:
-        pos = event.GetPosition()
-        device_scale = (  # pyright: ignore[reportUnknownVariableType]
-            self.GetContentScaleFactor()
-        )
-        return wx.Point(
-            int(pos.x * device_scale),  # pyright: ignore[reportUnknownArgumentType]
-            int(pos.y * device_scale),  # pyright: ignore[reportUnknownArgumentType]
-        )
-
     def on_mouse_release_left(self, event: wx.MouseEvent):
         if self._mouse_captured:
             self.ReleaseMouse()
@@ -146,6 +136,16 @@ class GlWidget(GLCanvas):
                 distance,
             )
         self.Refresh(False)
+
+    def _get_scaled_position(self, event: wx.MouseEvent) -> wx.Point:
+        pos = event.GetPosition()
+        device_scale = (  # pyright: ignore[reportUnknownVariableType]
+            self.GetContentScaleFactor()
+        )
+        return wx.Point(
+            int(pos.x * device_scale),  # pyright: ignore[reportUnknownArgumentType]
+            int(pos.y * device_scale),  # pyright: ignore[reportUnknownArgumentType]
+        )
 
     def on_mouse_move(self, event: wx.MouseEvent):
         """


### PR DESCRIPTION
On  mouse wheel movements, the camera should move towards the point underneath the mouse pointer.  This was working on Windows but not macos on a Retina screen.  The problem was that event.GetPosition() in wx get the logical coords and not the screen coords.  

This is fixed by called self.GetContentScaleFactor() and using the result to scale the position returned from GetPosition().

This PR also made  a change to only capture the mouse if it wasn't already captured, and only release if it is captured to avoid the error `in ReleaseMouse(): Releasing mouse capture but capture stack empty?`
