### PR TITLE
feat: Adjust logging so that the loaded module can write logs

### DIFF
--- a/examples/mushroom.py
+++ b/examples/mushroom.py
@@ -1,4 +1,9 @@
+import logging
+
 from trimesh.creation import annulus, box, icosphere
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 MILLIS_PER_INCH = 25.4
 STEM_R_MAX = 6.5 / 2.0
@@ -7,6 +12,7 @@ TOP_R = 7.25 / 2.0
 
 
 def create_mesh():
+    logging.debug("Creating mushroom mesh")
     top = icosphere(radius=TOP_R * MILLIS_PER_INCH).apply_scale([1.0, 1.0, 0.5])
     cut = box(
         [9 * MILLIS_PER_INCH, 9 * MILLIS_PER_INCH, 4.5 * MILLIS_PER_INCH]

--- a/src/meshsee/__main__.py
+++ b/src/meshsee/__main__.py
@@ -1,14 +1,15 @@
 if __name__ == "__main__":
     # Load modules only when needed to speed up initial import before showing splash
-    import logging
 
-    from meshsee.logging_main import configure_logging, parse_logging_level
+    from meshsee.logging_main import (
+        DEFAULT_LOG_LEVEL,
+        configure_logging,
+        parse_logging_level,
+    )
 
-    # setup_logging()
     LOG_QUEUE_SIZE = 1000
-    DEFAULT_LOG_LEVEL = logging.WARNING
 
-    logging_listener = configure_logging(DEFAULT_LOG_LEVEL)
+    configure_logging(DEFAULT_LOG_LEVEL)
     parse_logging_level()
 
     from meshsee.ui.splash import start_splash_process

--- a/src/meshsee/app.py
+++ b/src/meshsee/app.py
@@ -16,6 +16,7 @@ def main(splash_conn: Connection):
     renderer_factory = RendererFactory(CameraPerspective())
     gl_widget_adapter = GlWidgetAdapter(renderer_factory)
     controller = Controller()
+    logger.warning("*** Meshee has initialized ***")
     stop_splash_process(splash_conn)
     GlUi(controller, gl_widget_adapter).run()
     logger.info("Meshee app stopping")

--- a/src/meshsee/controller.py
+++ b/src/meshsee/controller.py
@@ -36,7 +36,10 @@ class Controller:
         self._load_queue = MpLoadQueue(maxsize=1, type_=LoadResult)
         self._command_queue = MpCommandQueue(maxsize=0, type_=Command)
         self._loader_process = MeshLoaderProcess(
-            self._command_queue, self._load_queue, log_queue=log_queue
+            self._command_queue,
+            self._load_queue,
+            log_queue=log_queue,
+            log_level=logger.getEffectiveLevel(),
         )
         self._loader_process.start()
         self.on_load_status_change = Observable()

--- a/src/meshsee/logging_main.py
+++ b/src/meshsee/logging_main.py
@@ -7,6 +7,7 @@ import multiprocessing as mp
 import multiprocessing.queues as mp_queues
 
 LOG_QUEUE_SIZE = 1000
+DEFAULT_LOG_LEVEL = logging.WARNING
 
 log_queue: mp_queues.Queue[logging.LogRecord] = mp.Queue(maxsize=LOG_QUEUE_SIZE)
 
@@ -28,7 +29,7 @@ def configure_logging(log_level: int) -> logging.handlers.QueueListener:
     listener = logging.handlers.QueueListener(
         log_queue,
         console,
-        respect_handler_level=True,
+        respect_handler_level=False,
     )
     listener.start()
 

--- a/src/meshsee/logging_worker.py
+++ b/src/meshsee/logging_worker.py
@@ -5,9 +5,11 @@ import logging.handlers
 import multiprocessing.queues as mp_queues
 
 
-def configure_worker_logging(log_queue: mp_queues.Queue[logging.LogRecord]) -> None:
+def configure_worker_logging(
+    log_queue: mp_queues.Queue[logging.LogRecord], log_level: int
+) -> None:
     queue_handler = logging.handlers.QueueHandler(log_queue)
-    queue_handler.setLevel(logging.DEBUG)
+    queue_handler.setLevel(log_level)
     root = logging.getLogger()
     root.handlers.clear()
     root.addHandler(queue_handler)

--- a/src/meshsee/mesh_loader_process.py
+++ b/src/meshsee/mesh_loader_process.py
@@ -190,15 +190,21 @@ class MeshLoaderProcess(Process):
         command_queue: MpCommandQueue,
         load_queue: MpLoadQueue,
         log_queue: mp_queues.Queue[logging.LogRecord],
+        log_level: int,
     ):
         super().__init__()
         self._command_queue = command_queue
         self._load_queue = load_queue
         self._worker: LoadWorker | None = None
         self._log_queue = log_queue
+        self._log_level = log_level
 
     def run(self) -> None:
-        configure_worker_logging(self._log_queue)
+        # Set logging level for the loaded module; it can be changed in that module
+        configure_worker_logging(self._log_queue, logging.DEBUG)
+
+        # Set the level for the logger in the function to the level passed
+        logger.setLevel(self._log_level)
 
         while True:
             try:

--- a/src/meshsee/ui/splash.py
+++ b/src/meshsee/ui/splash.py
@@ -36,7 +36,7 @@ def stop_splash_process(conn: Connection) -> None:
 
 def _splash_worker(conn: Connection, log_q: mp_queues.Queue[logging.LogRecord]) -> None:
     """Runs in a separate process: show Tk splash until told to close."""
-    configure_worker_logging(log_q)
+    configure_worker_logging(log_q, logger.getEffectiveLevel())
     logger.debug("worker starting")
     root, splash = create_splash_window()  # type: ignore[reportUnknownVariableType]
 

--- a/tests/test_logging_worker.py
+++ b/tests/test_logging_worker.py
@@ -22,11 +22,11 @@ def root_logger():
 
 def test_configure_worker_logging_sets_queue_handler(root_logger):
     log_queue = mp.Queue()
-    configure_worker_logging(log_queue)
+    configure_worker_logging(log_queue, logging.INFO)
 
     assert root_logger.level == logging.DEBUG
     assert len(root_logger.handlers) == 1
     handler = root_logger.handlers[0]
     assert isinstance(handler, logging.handlers.QueueHandler)
-    assert handler.level == logging.DEBUG
+    assert handler.level == logging.INFO
     assert handler.queue is log_queue


### PR DESCRIPTION
## 📌 Summary
This enables the loaded module to set the logging level and so that its logs are written to the console.
---

## 🔍 Description of Changes

Logging had been set up to enable subprocesses to sent logs to the main process via a queue.
The enable logging from sub-processes, but only the logs at the level or higher set in the main
process were written to the console.

This change:
- Does not respect the queue handlers logging level, so that logs sent into the queue are always accepted, 
   even if below the level set on the handler.
- Set the root logging level for the module loading process to debug so that all messages are enabled from the loaded module
- Sets up a second logger so that the code around loading the module uses the level set to the level in the main process.

- [X] New feature  
- [ ] Bug fix  
- [ ] Performance improvement  
- [ ] Documentation update  
- [ ] Refactor / internal change  
- [ ] Other (explain below)

**Detailed explanation:**

See the description.


## 🧪 Testing

Tests were adjusted for this change
---

## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [X] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [X] No  

---

## ✔️ Checklist

Before requesting review, confirm the following:

- [X] The code follows MeshSee’s coding standards (PEP 8, type hints, etc.).  
- [X] Tests pass locally.  
- [X] My changes include or update tests where appropriate.  
- [X] I have run linting tools (e.g., `ruff`).  
- [X] I have updated documentation where needed.  
- [X] I agree that my contributions are licensed under the **Apache-2.0 License**.
