### PR TITLE
bug/Enable executing as scadview

### DIFF
--- a/docs/create_mesh.md
+++ b/docs/create_mesh.md
@@ -63,7 +63,7 @@ for example if you are removing hidded voids.
 
 ## Output and Logging
 
-Console output goes to the terminal where you launched `python -m {{ package_name }}`.
+Console output goes to the terminal where you launched `{{ package_name }}`.
 You can use `print(...)` or Python's `logging` module inside your script. If you
 need more detail, you can set the logging level in your script.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ and loading it from the {{ project_name }} UI.
 
 1.  Create a new python file, and 
 1.  Write a `create_mesh` function code to build a Trimesh object.  
-1.  Run {{ project_name }} `python -m {{ package_name }}`
+1.  Run {{ project_name }} on the command line via: `{{ package_name }}`
 1.  Load the Python file into {{ project_name }}.
 1.  {{ project_name }} shows you the mesh.  You can move the camera around to inspect your mesh.
 1.  Edit your Python file to modify your mesh.
@@ -60,7 +60,7 @@ If you already have a project using Trimesh set up, install {{ package_name }} i
 
 ### Running
 
-To run: `python -m {{ package_name }}`
+To run: `{{ package_name }}`
 
 The first time you run, 
 it can take some time to set up the user interface,

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -44,11 +44,7 @@ def create_mesh():
 1.  Let's see what it looks like. 
 If you haven't already, run from the command line:
 ```bash
-python -m {{ package_name }}
-```
-Or you may need to run:
-```bash
-python3 -m {{ package_name }}
+{{ package_name }}
 ```
 The {{ project_name }} UI should appear.
 1.  Click the "Load py..." button.

--- a/src/scadview/__init__.py
+++ b/src/scadview/__init__.py
@@ -70,3 +70,9 @@ def __getattr__(name: str):
 def __dir__() -> list[str]:
     # Helps tools that use dir() to discover members
     return sorted(list(globals().keys()) + list(_lazy_map.keys()))
+
+
+def main():
+    from scadview.__main__ import main as main_func
+
+    main_func()

--- a/src/scadview/__main__.py
+++ b/src/scadview/__main__.py
@@ -1,4 +1,4 @@
-if __name__ == "__main__":
+def main():
     # Load modules only when needed to speed up initial import before showing splash
 
     from scadview.logging_main import (
@@ -6,8 +6,6 @@ if __name__ == "__main__":
         configure_logging,
         parse_logging_level,
     )
-
-    LOG_QUEUE_SIZE = 1000
 
     configure_logging(DEFAULT_LOG_LEVEL)
     parse_logging_level()
@@ -18,3 +16,7 @@ if __name__ == "__main__":
     from scadview.app import main
 
     main(splash_conn)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📌 Summary

**What does this PR do?**  
- Solves issue #78.
---

## 🧩 Related Issues

If this PR addresses or closes an issue, reference it here:

Fixes #78  

---

## 🔍 Description of Changes

Please describe the main changes in this PR and check all that apply:

- [ ] New feature  
- [X] Bug fix  
- [ ] Performance improvement  
- [ ] Documentation update  
- [ ] Refactor / internal change  
- [ ] Other (explain below)

**Detailed explanation:**

-  Adds a `main()` function to `__init__.py`, so that running `scadview` starts the UI
-  This relies on a section in the `pyproject.toml` file, which already existed:
```toml
[project.scripts]
scadview = "scadview:main"
```
- Documentation was update, replacing `python -m scadview` and similar with `scadview`

---

## 🧪 Testing
N/A
---

## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [X] I updated or added relevant documentation in `/docs`  
- [ ] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [X] No  

---

## 🧠 Additional Notes

None
---

## ✔️ Checklist

Before requesting review, confirm the following:

- [X] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [X] Tests pass locally.  
- [X] My changes include or update tests where appropriate.  
- [ ] I have run linting tools (e.g., `ruff`).  
- [ ] I have updated documentation where needed.  
- [ ] I agree that my contributions are licensed under the **Apache-2.0 License**.
