### PR TITLE
fix: Add Resolves #__ for issue link to auto-close the issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,8 @@ Each PR must have an associated issue.
 If this one does not, create one.
 -->
 
-**Issue # (__required__):** #__
+**Issue # (__required__):**  
+Resolves #__
 
 <!--
 What does this PR do?


### PR DESCRIPTION
# SCADview Pull Request

--- 

## 📌 Summary

**Issue # (__required__):** 
Resolves #89 

<!--
What does this PR do?

Give a short, clear explanation of the change or feature.

- What problem does it solve?
- What new capability does it introduce?
- Why is this behavior desirable?
-->

By adding the word "resolves" in front of the linked issue #, github will automatically close the issue when the PR is merged.

---

## 🔍 Description of Changes

See summary

## 🧪 Testing

- [X] Not applicable

---

<!-- This section is REQUIRED! -->
## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [X] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [X] No  

---
## ✔️ Checklist

Before requesting review, confirm the following:

- [X] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [X] I have run `make preflight` and all stages pass
- [X] My changes include or update tests where appropriate.  
- [X] I have updated documentation where needed.  
- [X] I agree that my contributions are licensed under the **Apache-2.0 License**.
