### PR TITLE
chore: Add PyPI test index to pyproject.toml to enable test releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,12 @@ scadview = "scadview:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+publish-url = "https://test.pypi.org/legacy/"
+explicit = true
+
 [dependency-groups]
 dev = [
     "click==8.2.1",


### PR DESCRIPTION
# SCADview Pull Request
---

## 📌 Summary

**Issue # (__required__):**  
Resolves #97 

This adds the TestPyPI index to pyproject.toml

---

## 🔍 Description of Changes

See summary,

## 🧪 Testing

- Released to test.pypi.org and pypi.org manually

---

<!-- This section is REQUIRED! -->
## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [X] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [X] No  

---

## ✔️ Checklist

Before requesting review, confirm the following:

- [X] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [X] I have run `make preflight` and all stages pass
- [X] My changes include or update tests where appropriate.  
- [X]  I have updated documentation where needed.  
- [X] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [X] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
