### PR TITLE
Replace development instructions with getting started in README 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,12 @@ All contributions are made via pull requests (PRs) from a fork to ensure a clean
 
 ---
 
+## Requirements:
+- Python
+- uv
+- make
+
+
 ## TL;DR (Quick Start)
 
 ```
@@ -90,7 +96,32 @@ Examples:
 
 ---
 
-### 4. Make Your Changes
+### 4. Set Up the Development Environment
+
+This project uses `make` for commmon tasks. 
+
+**Window Development**: Use Git Bash (included with Git for Windows) for these commands.
+
+- Most of the make commands require that you run `make shell` first.
+- To get a list of available commands:
+```
+make help
+```
+- To get into the shell:
+```
+make shell
+```
+- This will create a virtual python environment if it does not already exist.
+
+- To run:
+
+```
+make run
+```
+
+
+
+### 5. Make Your Changes
 
 - Keep changes focused and scoped to the issue
 - **Follow coding standards**, as noted below.
@@ -100,7 +131,7 @@ Examples:
 
 ---
 
-### 5. Commit Your Changes
+### 6. Commit Your Changes
 
 This project uses **[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)**.
 
@@ -139,7 +170,7 @@ ci: | GitHub Actions / CI | Patch
 
 ---
 
-### 6. Run Preflight Checks
+### 7. Run Preflight Checks
 
 Before submitting your PR, ensure your changes pass all local checks:
 
@@ -153,7 +184,7 @@ CI failures will block merging.
 
 ---
 
-### 7. Push to Your Fork
+### 8. Push to Your Fork
 
 ```bash
 git push origin <your-branch-name>
@@ -161,7 +192,7 @@ git push origin <your-branch-name>
 
 ---
 
-### 8. Open a Pull Request
+### 9. Open a Pull Request
 
 Open a PR from your fork to the `main` branch of the upstream repository.
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,148 @@
 # SCADview
 An application to view 3D meshes created from Python.
 
-## Development
-### Requirements:
-- Python
-- uv
-- make
+## How it works
+
+SCADview enables a iterative work flow to build Trimesh objects.
+
+1.  Create a new python file, and 
+1.  Write a `create_mesh` function code to build a Trimesh object.  
+1.  Run SCADview on the command line via: `scadview`
+1.  Load the Python file into SCADview.
+1.  SCADview shows you the mesh.  You can move the camera around to inspect your mesh.
+1.  Edit your Python file to modify your mesh.
+1.  Reload and view the modified mesh.
+1.  Repeat the edits and reloads.
+
+## Getting Started
+
+### Installation
+
+Open your terminal application
+for example `cmd` in Windows
+or `Terminal.app` under Applications > Utilties > Terminal.app in macOS.
+
+In the terminal, check that you have Python 3.11 or greater via
+
+`python --version`
+
+or, if the `python` command cannot be found:
+
+`python3 --version`
+
+If Python 3.11 or greater is installed on your system, 
+you can install SCADview directly into your system.
+
+#### Virtual venv option
+
+As is always a good practice, 
+set up a Python virtual environment and activate it: 
+- see [Creating virtual environments](https://docs.python.org/3/library/venv.html#creating-virtual-environments).
+
+#### Install Trimesh
+
+First install Trimesh so you can script your 3d models 
+(if using a virtual environment, activate it first):
+
+`pip install trimesh`
+
+Trimesh has optional modules you can add.  
+Read its docs to determine which ones will help you most.
+
+#### Install SCADview
+
+To install, SCADview run 
+
+`pip install scadview`
+
+If you already have a project using Trimesh set up, install scadview into that project instead and install there.
+
+### Running
+
+To run: `scadview`
+
+The first time you run, 
+it can take some time to set up the user interface,
+and so it may take longer than when you run it in future runs.
+
+A splash screen may show on startup.  
+If it is not available,
+you will see a message in the terminal output:
+```
+WARNING scadview.ui.splash_window: The splash screen is not available so it will not be shown.
+```
+Otherwise, you will see:
+
+![Splash](./docs/images/splash_window.png){ .md-image width=400 }
+
+Once it has initialized, you should see the main user interface:
+![Startup Window](./docs/images/startup_window.png){ .md-image width=700 }
+
+Notice that your terminal shows output from the scadview module.
+
+### Loading in your model
+
+Using a code editor,
+create a file with the following python code:
+
+```python
+from trimesh.creation import icosphere
+
+
+def create_mesh():
+    return icosphere(radius=40, subdivisions=3)
+```
+
+Notice that you don't need to import the scadview package.
+
+Save the file:
+
+- If you did not create a virtual environment,
+you can save it anywhere on your system.
+- If you installed in a virtual environment,
+save your file in that folder.
+
+Use the Load button on the SCADview UI to load the file.
+
+You should see a sphere!
+![sphere](./docs/images/getting_started_ball.png)
+
+### Modify and reload
+
+Now change the subdivisions parameter in your code to 2:
+
+```python
+from trimesh.creation import icosphere
+
+
+def create_mesh():
+    return icosphere(radius=40, subdivisions=2)
+```
+
+Click Reload. You should see an updated sphere with fewer triangles.
+![sphere_2](./docs/images/getting_started_ball_2.png)
+
+### Export
+
+Once you are happy with your mesh, 
+you can export it for 3d printing
+or for loading other 3d software.
+
+1. Click the `Export` button.
+1. Choose a format. 
+1. Click Save.
+
+The Export dialog may look different on your computer.
+![export](./docs/images/getting_started_export.png)
+
+
+
 
 ## Versioning
 SCADview follows [Semantic Versioning 2.0.0](https://semver.org/).  
 In short: MAJOR versions for incompatible API changes, MINOR for backward-compatible
 features, and PATCH for backward-compatible bug fixes. While the major version
 is 0, we may introduce breaking changes in minor releases.
-
-### Set up
-This project uses `make` for commmon tasks. 
-- Most of the make commands require that you run `make shell` first.
-- To get a list of available commands:
-```
-make help
-```
-- To get into the shell:
-```
-make shell
-```
-- This will create a virtual python environment if it does not already exist.
-
 
 ---
 
@@ -38,7 +155,7 @@ applications — provided you include the license text above and retain copyrigh
 
 ---
 
-### ⚠️ Disclaimer
+## ⚠️ Disclaimer
 
 SCADview is provided **“as is”**, without warranty of any kind.
 It is intended for visualization, analysis, and experimentation purposes.
@@ -47,7 +164,7 @@ Use at your own discretion.
 
 ---
 
-### 🏷️ Name and Branding
+## 🏷️ Name and Branding
 
 The name **SCADview** and its associated logo are trademarks of **Neil Lamoureux**.  
 While you are free to fork and modify the code under the Apache License,  

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ Read its docs to determine which ones will help you most.
 
 To install, {{ project_name }} run 
 
-`pip install git+https://github.com/neillamoureux/{{ package_name }}.git@main`
+`pip install {{ package_name }}`
 
 If you already have a project using Trimesh set up, install {{ package_name }} into that project instead and install there.
 


### PR DESCRIPTION
# SCADview Pull Request
---

## 📌 Summary

**Issue # (__required__):**  
Resolves #99 

---
## 🔍 Description of Changes

- Adds end-user instructions to README  
-  Move items in README under the "Development" heading to CONTRIBUTING.md

## 🧪 Testing
- [X] Not applicable

---

## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [X] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [X] No  

---

## ✔️ Checklist

Before requesting review, confirm the following:

- [X] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [X] I have run `make preflight` and all stages pass
- [X] My changes include or update tests where appropriate.  
- [X] I have updated documentation where needed.  
- [X] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [X] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
