### PR TITLE
docs: Add project.urls in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,13 @@ dependencies = [
 [project.scripts]
 scadview = "scadview:main"
 
+[project.urls]
+Homepage = "https://scadview.org"
+Documentation = "https://scadview.org"
+Repository = "https://github.com/neillamoureux/scadview"
+Issues = "https://github.com/neillamoureux/scadview/issues"
+Changelog = "https://github.com/neillamoureux/scadview/blob/main/CHANGELOG.md"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
# SCADview Pull Request
---

## 📌 Summary

**Issue # (__required__):**  
Resolves #105

This add project.urls to the `pyproject.toml` file so that these links are visible on PyPI
---
## 🔍 Description of Changes

See summary  

## 🧪 Testing

- Manually built and uploaded to TestPyPI

---

<!-- This section is REQUIRED! -->
## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [X] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [X] No  

---

## ✔️ Checklist

Before requesting review, confirm the following:

- [X] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [X] I have run `make preflight` and all stages pass
- [X] My changes include or update tests where appropriate.  
- [X] I have updated documentation where needed.  
- [X] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [X] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
