### PR TITLE
fix: When resizing the gl viewport, set size using scaled values

### DIFF
--- a/src/scadview/ui/wx/gl_widget.py
+++ b/src/scadview/ui/wx/gl_widget.py
@@ -88,9 +88,10 @@ class GlWidget(GLCanvas):
         size: wx.Size = (  # pyright: ignore[reportUnknownVariableType]
             self.GetClientSize()
         )
+        scale = self.GetContentScaleFactor()  # pyright: ignore[reportUnknownVariableType]
         self._gl_widget_adapter.resize(
-            size.width,  # pyright: ignore[reportUnknownArgumentType]
-            size.height,  # pyright: ignore[reportUnknownArgumentType]
+            int(scale * size.width),  # pyright: ignore[reportUnknownArgumentType]
+            int(scale * size.height),  # pyright: ignore[reportUnknownArgumentType]
         )
         self.Refresh(False)
 


### PR DESCRIPTION
# SCADview Pull Request
---

## 📌 Summary

**Issue # (__required__):**  
Resolves #119

**Problem**: after resizing, moving the camera forward or backward using the mouse wheel was not keeping the 3d points in the gl viewport under the mouse pointer in place.  The issue was that `GlWidget` in `src/scadview/ui/wx/gl_widget.py`, a wx `GLCanvas`, was passing unscaled device coordinates to the `GlWidgetAdapter` in `src/scadview/render/gl_widget_adapter.py`.  

**Solution**: Get the device coordinate scale via `self.GetContentScaleFactor()`, and scale the physical coords to logical coords using this value, passing it to the `GlWidgetAdapter.resize()` function.

-- 
## 🔍 Description of Changes

See the summary.

## 🧪 Testing

- Manually tested by resizing and moving the camera using the scroll wheel
- Tested on macOS.

Note there are no automated tests; we don't have a good way to test wx widgets, where the fix resides.
---

<!-- This section is REQUIRED! -->
## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [X] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [X] No  
---


## ✔️ Checklist

Before requesting review, confirm the following:

- [X] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [X] I have run `make preflight` and all stages pass
- [X] My changes include or update tests where appropriate.  
- [X] I have updated documentation where needed.  
- [x] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [X] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
