### PR TITLE
fix: Update pixel scale factor to correct cam moves when scale changes

### DIFF
--- a/src/scadview/ui/wx/gl_widget.py
+++ b/src/scadview/ui/wx/gl_widget.py
@@ -69,6 +69,7 @@ class GlWidget(GLCanvas):
         self.on_gnomon_change = self._gl_widget_adapter.on_gnomon_change
 
         self._mouse_captured = False
+        self._last_pixel_size: tuple[int, int] | None = None
 
     @property
     def show_grid(self):
@@ -84,15 +85,7 @@ class GlWidget(GLCanvas):
         self.Refresh()
 
     def on_size(self, _evt: wx.SizeEvent):
-        # Just schedule a repaint; set viewport during paint when context is current.
-        size: wx.Size = (  # pyright: ignore[reportUnknownVariableType]
-            self.GetClientSize()
-        )
-        scale = self.GetContentScaleFactor()  # pyright: ignore[reportUnknownVariableType]
-        self._gl_widget_adapter.resize(
-            int(scale * size.width),  # pyright: ignore[reportUnknownArgumentType]
-            int(scale * size.height),  # pyright: ignore[reportUnknownArgumentType]
-        )
+        self._sync_pixel_size()
         self.Refresh(False)
 
     def on_paint(self, _evt: wx.PaintEvent):
@@ -105,6 +98,7 @@ class GlWidget(GLCanvas):
         dc = wx.PaintDC(self)
         del dc
         self.SetCurrent(self.ctx_wx)
+        self._sync_pixel_size()
         size = self.GetClientSize()  # pyright: ignore[reportUnknownVariableType]
         scale = (  # pyright: ignore[reportUnknownVariableType]
             self.GetContentScaleFactor()
@@ -130,6 +124,7 @@ class GlWidget(GLCanvas):
         self._gl_widget_adapter.end_orbit()
 
     def on_mouse_wheel(self, event: wx.MouseEvent):
+        self._sync_pixel_size()
         if event.GetWheelAxis() == wx.MOUSE_WHEEL_VERTICAL:
             distance = event.GetWheelRotation()
             position = self._get_scaled_position(event)
@@ -139,6 +134,17 @@ class GlWidget(GLCanvas):
                 distance,
             )
         self.Refresh(False)
+
+    def _sync_pixel_size(self, force: bool = False):
+        size: wx.Size = self.GetClientSize()  # pyright: ignore[reportUnknownVariableType]
+        scale = self.GetContentScaleFactor()  # pyright: ignore[reportUnknownVariableType]
+        pixel_size = (
+            int(scale * size.width),  # pyright: ignore[reportUnknownArgumentType]
+            int(scale * size.height),  # pyright: ignore[reportUnknownArgumentType]
+        )
+        if force or self._last_pixel_size != pixel_size:
+            self._gl_widget_adapter.resize(pixel_size[0], pixel_size[1])
+            self._last_pixel_size = pixel_size
 
     def _get_scaled_position(self, event: wx.MouseEvent) -> wx.Point:
         pos = event.GetPosition()


### PR DESCRIPTION
# SCADview Pull Request

---

## 📌 Summary


**Issue # (__required__):**  
Resolves #125

This solves the problem of camera dolly in and out; the point under the mouse pointer can shift when it should stay still.  This can happen when pixel scale changes, eg when moving the app from a Retina screen (scale = 2) to a standard screen (scale = 1).

---

## 🧩 Related Issues <!-- Optional section; delete if not needed -->


Related to 
- #119 

---

## 🔍 Description of Changes

<!-- Please describe the main changes in this PR  -->

- Gets the pixel scale factor from wx whenever the window moves, on paint and on mouse scroll events
- Call the GlWidgetAdapter resize method when this happens.

## 🧪 Testing

<!-- 
If no tests needed, check the line below
Otherwise delete it.
-->
- [] Not applicable

- The change is in wx-related code and we don't have a good way to test that automatically yet.
- Manually tested moving between  a Retina screen and a standard screen

---

<!-- This section is REQUIRED! -->
## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [X] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [X] No  

---


## ✔️ Checklist

Before requesting review, confirm the following:

- [X] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [X] I have run `make preflight` and all stages pass
- [X] My changes include or update tests where appropriate.  
- [X] I have updated documentation where needed.  
- [X] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [X] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
