### PR TITLE
fix: Check for NaN coords on load and log error if found

### DIFF
--- a/src/scadview/mesh_loader_process.py
+++ b/src/scadview/mesh_loader_process.py
@@ -11,6 +11,7 @@ from time import time
 from typing import Any, Generator, Generic, Type, TypeVar
 
 import numpy as np
+from manifold3d import Error as ManifoldError
 from manifold3d import Manifold
 from trimesh import Trimesh
 
@@ -236,6 +237,7 @@ class LoadWorker(Thread):
             self._check_trimesh_vertices(mesh)
             return
         if isinstance(mesh, Manifold):
+            self._check_manifold(mesh)
             return
         if isinstance(mesh, list):
             for i, m in enumerate(mesh):  # type: ignore[reportUnknowVariableType] - can't resolve
@@ -243,6 +245,7 @@ class LoadWorker(Thread):
                     self._check_trimesh_vertices(m)
                     continue
                 if isinstance(m, Manifold):
+                    self._check_manifold(m, i)
                     continue
                 if not isinstance(m, Trimesh) and not isinstance(m, Manifold):
                     raise TypeError(
@@ -266,6 +269,15 @@ class LoadWorker(Thread):
         raise ValueError(
             f"Mesh contains non-finite vertex coordinate {invalid_value} at vertices[{vertex_index}][{coord_index}]"
         )
+
+    def _check_manifold(self, mesh: Manifold, list_index: int | None = None):
+        status = mesh.status()
+        if status == ManifoldError.NoError:
+            return
+        prefix = "Manifold mesh"
+        if list_index is not None:
+            prefix = f"Manifold mesh[{list_index}]"
+        raise ValueError(f"{prefix} has invalid status: {status.name}")
 
     def cancel(self):
         self.cancelled = True

--- a/src/scadview/mesh_loader_process.py
+++ b/src/scadview/mesh_loader_process.py
@@ -10,6 +10,7 @@ from threading import Thread
 from time import time
 from typing import Any, Generator, Generic, Type, TypeVar
 
+import numpy as np
 from manifold3d import Manifold
 from trimesh import Trimesh
 
@@ -151,6 +152,7 @@ class LoadWorker(Thread):
                     return
                 self._update_mesh(sequence_number, mesh)
         except Exception as e:
+            logger.exception("Failed to load mesh from %s", self.module_path)
             self._update_mesh(sequence_number, last_mesh, final=True, error=e)
             return
         self._update_mesh(sequence_number, last_mesh, final=True)
@@ -231,11 +233,17 @@ class LoadWorker(Thread):
 
     def _check_mesh_type(self, mesh: Any):
         if isinstance(mesh, Trimesh):
+            self._check_trimesh_vertices(mesh)
             return
         if isinstance(mesh, Manifold):
             return
         if isinstance(mesh, list):
             for i, m in enumerate(mesh):  # type: ignore[reportUnknowVariableType] - can't resolve
+                if isinstance(m, Trimesh):
+                    self._check_trimesh_vertices(m)
+                    continue
+                if isinstance(m, Manifold):
+                    continue
                 if not isinstance(m, Trimesh) and not isinstance(m, Manifold):
                     raise TypeError(
                         f"Expected mesh[{i}] to be of type Trimesh or Manifold, got {type(m)}"  # type: ignore[reportUnknowArgumentType] - can't resolve
@@ -243,6 +251,20 @@ class LoadWorker(Thread):
             return
         raise TypeError(
             f"Expected mesh to be of type Trimesh, list[Trimesh], Manifold, or list[Manifold], got {type(mesh)}"
+        )
+
+    def _check_trimesh_vertices(self, mesh: Trimesh):
+        if mesh.vertices.size == 0:
+            return
+        invalid_indices = np.argwhere(~np.isfinite(mesh.vertices))
+        if invalid_indices.size == 0:
+            return
+        first_invalid = invalid_indices[0]
+        vertex_index = int(first_invalid[0])
+        coord_index = int(first_invalid[1])
+        invalid_value = mesh.vertices[vertex_index, coord_index]
+        raise ValueError(
+            f"Mesh contains non-finite vertex coordinate {invalid_value} at vertices[{vertex_index}][{coord_index}]"
         )
 
     def cancel(self):

--- a/tests/test_mesh_loader_process.py
+++ b/tests/test_mesh_loader_process.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import manifold3d
 import numpy.testing as npt
 import pytest
 from trimesh.creation import box, icosphere
@@ -222,6 +223,26 @@ def test_load_worker_errors_on_nan_vertices(load_queue):
     with patch("scadview.mesh_loader_process.ModuleLoader") as mock_module_loader:
         ml_instance = mock_module_loader.return_value
         ml_instance.run_function.return_value = iter([nan_mesh])
+        worker = LoadWorker("test/path", load_queue)
+        LoadWorker.load_number = 0
+        worker.load()
+
+    result = load_queue.get(timeout=1.0)
+    assert result.error is not None
+    assert isinstance(result.error, ValueError)
+    assert result.status == LoadStatus.ERROR
+
+
+def test_load_worker_errors_on_non_finite_manifold_vertices(load_queue):
+    base_mesh = manifold3d.Manifold.cube().to_mesh()
+    vertices = base_mesh.vert_properties.copy()
+    vertices[0, 0] = float("inf")
+    invalid_manifold = manifold3d.Manifold(
+        manifold3d.Mesh(vertices.astype("f4"), base_mesh.tri_verts.copy())
+    )
+    with patch("scadview.mesh_loader_process.ModuleLoader") as mock_module_loader:
+        ml_instance = mock_module_loader.return_value
+        ml_instance.run_function.return_value = iter([invalid_manifold])
         worker = LoadWorker("test/path", load_queue)
         LoadWorker.load_number = 0
         worker.load()

--- a/tests/test_mesh_loader_process.py
+++ b/tests/test_mesh_loader_process.py
@@ -216,6 +216,22 @@ def test_load_worker_colors_mesh_list(load_queue):
         assert tm.metadata["scadview"]["color"][3] == 0.5
 
 
+def test_load_worker_errors_on_nan_vertices(load_queue):
+    nan_mesh = box()
+    nan_mesh.vertices[0] = [float("nan"), 0.0, 0.0]
+    with patch("scadview.mesh_loader_process.ModuleLoader") as mock_module_loader:
+        ml_instance = mock_module_loader.return_value
+        ml_instance.run_function.return_value = iter([nan_mesh])
+        worker = LoadWorker("test/path", load_queue)
+        LoadWorker.load_number = 0
+        worker.load()
+
+    result = load_queue.get(timeout=1.0)
+    assert result.error is not None
+    assert isinstance(result.error, ValueError)
+    assert result.status == LoadStatus.ERROR
+
+
 @pytest.mark.skip  # Flakey
 def test_load_worker_cancel(started_load_worker):
     assert started_load_worker.is_alive()


### PR DESCRIPTION
## 📌 Summary

**Issue # (__required__):**  
Resolves #137

This PR fixes a load-path bug where meshes with non-finite coordinates (`NaN`/`Inf`) were not consistently surfaced as load failures.

`LoadWorker` now validates both `Trimesh` vertex data and `Manifold` status before accepting a mesh, and logs the loader exception when validation fails. This ensures invalid mesh data results in an explicit error state rather than leaving the app in an inconsistent load state.

---

## 🔍 Description of Changes

- Added mesh validation in `LoadWorker._check_mesh_type` for:
  - `Trimesh` vertex coordinates via `np.isfinite`
  - `Manifold` validity via `mesh.status()`
  - both direct returns and list-return debug payloads
- Added helper checks:
  - `_check_trimesh_vertices(...)`
  - `_check_manifold(...)`
- Added explicit error logging in loader exception path:
  - `logger.exception("Failed to load mesh from %s", self.module_path)`
- Added regression tests in `tests/test_mesh_loader_process.py`:
  - `test_load_worker_errors_on_nan_vertices`
  - `test_load_worker_errors_on_non_finite_manifold_vertices`

## 🧪 Testing

- [ ] Not applicable

- `uv run pytest -q tests/test_mesh_loader_process.py`
- Verified both new regression tests fail before fix and pass after fix.

---

## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [x] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [x] No  

---

## 🧠 Additional Notes

- For invalid Manifold input, the raised error includes `Manifold.status()` (for example `NonFiniteVertex`) for clearer diagnosis.
- This change is limited to loader validation and error surfacing; no rendering or UI APIs were modified.

---

## ✔️ Checklist

Before requesting review, confirm the following:

- [x] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [x] I have run `mise preflight` and all stages pass
- [x] My changes include or update tests where appropriate.  
- [x] I have updated documentation where needed.  
- [x] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [x] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
