### PR TITLE
chore: Update AGENTS.md and add .codex/config.toml for codex agent

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,9 @@
+model = "gpt-5.4"
+
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+project_root_markers = [".git"]
+
+[features]
+codex_hooks = false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,11 @@ clean, testable, maintainable code and make changes that preserve existing
 architectural boundaries and project conventions.
 
 When making code changes, prefer small, focused diffs that keep behavior explicit
-and easy to verify with tests.
+and easy to verify.
+
+Favor incremental, inspectable changes over broad architectural rewrites.
+
+---
 
 ## Authoritative References
 
@@ -24,6 +28,8 @@ If guidance conflicts, follow this precedence:
 3. `STYLE.md` for code shape and implementation style.
 4. `CONTRIBUTING.md` for workflow and process expectations.
 
+---
+
 ## Working Rules
 
 - Keep dependency direction aligned with `ARCHITECTURE.md`.
@@ -35,6 +41,57 @@ If guidance conflicts, follow this precedence:
 - Keep functions small and focused; extract helpers instead of adding explanatory
   comments for complex blocks.
 - Prefer specific exceptions and explicit error paths.
+- Do not introduce new dependencies unless clearly justified.
+
+---
+
+## Change Strategy
+
+- Inspect first, then propose changes, then implement.
+- Prefer the smallest reviewable diff that solves the problem.
+- Avoid renames, file moves, or style-only changes unless required for correctness.
+- Preserve public behavior, CLI entry points, and documented workflows unless explicitly instructed otherwise.
+- When uncertain, add instrumentation or diagnostics before attempting a redesign.
+
+### GUI / Rendering Specific
+
+- For wxPython, ModernGL, or rendering issues:
+  1. Isolate the suspected code path first.
+  2. Add diagnostics (logging, counters, timestamps) before modifying logic.
+  3. Avoid speculative refactors of rendering or event-loop behavior.
+- Clearly distinguish between:
+  1. Code-level correctness
+  2. Visual correctness (which requires human validation)
+
+---
+
+## Validation
+
+- Run the smallest relevant validation first before broader checks.
+- Prefer targeted tests or commands over full-suite runs unless necessary.
+- Do not assume GUI tests are reliable or available in all environments.
+- After changes affecting rendering or UI behavior:
+  1. State what was changed
+  2. State what must be manually verified by a human
+
+---
+
+## Logging and Diagnostics
+
+- Prefer structured logging over ad hoc print statements.
+- Include useful context (process, thread, platform) when diagnosing issues.
+- Make diagnostic changes easy to remove after debugging.
+- Avoid leaving excessive debug noise in final code.
+
+---
+
+## Packaging, CI, and Docs
+
+- Treat `pyproject.toml`, GitHub Actions, and docs as user-facing interfaces.
+- Keep changes reproducible and minimal.
+- Do not modify release, publishing, or deployment behavior without explicitly stating it.
+
+---
 
 ## Validation Checklist
 
@@ -47,3 +104,10 @@ Before finishing substantial code changes:
 
 Recommended commands are defined in `CONTRIBUTING.md` (for example, `mise preflight`).
 
+---
+
+## Output Expectations
+
+- Summarize changes by file.
+- Call out assumptions when they affect correctness.
+- Prefer concise, technical explanations over verbose descriptions.


### PR DESCRIPTION
# SCADview Pull Request

---

## 📌 Summary

**Issue # (__required__):**  
Resolves #141

Adds Codex project configuration and expands the repository agent instructions so future coding agents have clearer guidance for change strategy, validation, diagnostics, packaging, and output expectations.

---

## 🔍 Description of Changes

- Added `.codex/config.toml` with the project Codex model, approval policy, sandbox mode, project root marker, and hook setting.
- Expanded `AGENTS.md` with guidance for incremental changes, dependency discipline, diagnostics, GUI/rendering work, validation, packaging, and response expectations.
- Removed test-specific wording from the opening guidance so verification can match the scope of each change.

## 🧪 Testing

- [x] Not applicable

This is a documentation and local agent-configuration change only. No runtime code paths were changed.

---

## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [x] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [x] No  

---

## 🧠 Additional Notes

- This PR does not change application behavior, packaging, CLI entry points, renderer behavior, or the user module contract.

---

## ✔️ Checklist

Before requesting review, confirm the following:

- [x] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [x] I have run `mise preflight` and all stages pass
- [x] My changes include or update tests where appropriate.  
- [x] I have updated documentation where needed.  
- [x] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [ ] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
