### PR TITLE
chore: replaced pyright with py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           uv run --no-sync ruff check --select I src tests examples
 
       - name: Run type checker
-        run: uv run --no-sync pyright --project pyright.ci.json
+        run: uv run --no-sync ty check --exclude src/scadview/ui/wx --force-exclude
 
       - name: Run tests
         env:

--- a/mise.toml
+++ b/mise.toml
@@ -48,18 +48,14 @@ depends = ["bootstrap"]
 run = "uv run --no-sync inv lint"
 
 [tasks.type]
-description = "Run pyright type checks"
+description = "Run ty type checks"
 depends = ["bootstrap"]
 run = "uv run --no-sync inv type"
 
 [tasks.type_ci]
-description = "Run CI pyright type checks"
+description = "Run CI ty type checks"
 depends = ["bootstrap_ci"]
 run = "uv run --no-sync inv type --ci"
-
-[tasks.type_ty]
-description = "Optional: run Astral ty type checks"
-run = "uvx ty check src"
 
 [tasks.test]
 description = "Run test suite"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "numpy==2.*",
     "pillow>=11.2.1",
     'pyobjc-framework-Cocoa; platform_system == "Darwin"',
-    "pyright>=1.1.408",
     "pyrr>=0.10.3",
     "scipy>=1.16.1",
     "shapely>=2.1.1",
@@ -55,67 +54,23 @@ dev = [
     "mkdocs-material>=9.6.22",
     "mkdocstrings-python>=1.18.2",
     "pymdown-extensions>=10.16.1",
-    "pyright>=1.1.407",
     "pytest>=8.3.4",
     "pytest-cov>=6.1.1",
     "pytest-mock>=3.14.0",
     "ruff>=0.9.2",
+    "ty>=0.0.31",
     "watchdog>=6.0.0",
 ]
 
 [tool.uv.sources]
 scadview = { workspace = true }
 
-[tool.pyright]
+[tool.ty.environment]
+python-version = "3.11"
+
+[tool.ty.rules]
+unused-ignore-comment = "error"
+unused-type-ignore-comment = "error"
+
+[tool.ty.src]
 include = ["src/scadview", "tasks.py"]
-venvPath = "."
-venv = ".venv"
-pythonVersion = "3.11"
-typeCheckingMode = "strict"
-useLibraryCodeForTypes = true
-
-# Treat "unknown"/"untyped" as errors
-reportUnknownParameterType = "error"
-reportUnknownArgumentType = "error"
-reportUnknownVariableType = "error"
-reportUnknownMemberType = "none"
-reportUntypedFunctionDecorator = "error"
-reportUntypedClassDecorator = "error"
-reportUntypedBaseClass = "error"
-reportUntypedNamedTuple = "error"
-
-# Everything correctness-related stays strict
-reportMissingImports = "error"
-reportMissingModuleSource = "error"
-reportPrivateUsage = "error"
-reportIncompatibleMethodOverride = "error"
-reportIncompatibleVariableOverride = "error"
-reportInvalidTypeVarUse = "error"
-reportMissingTypeArgument = "error"
-reportOptionalMemberAccess = "error"
-reportOptionalSubscript = "error"
-reportOptionalCall = "error"
-reportReturnType = "error"
-reportAssignmentType = "error"
-reportCallIssue = "error"
-reportGeneralTypeIssues = "error"
-reportMatchNotExhaustive = "error"
-reportUninitializedInstanceVariable = "none"
-reportUnboundVariable = "error"
-
-# Ignore missing type stubs
-reportMissingTypeStubs = "none"
-
-# Hygiene
-reportUnusedImport = "error"
-reportUnusedClass = "error"
-reportUnusedFunction = "error"
-reportUnusedVariable = "error"
-reportDuplicateImport = "error"
-reportUnnecessaryTypeIgnoreComment = "error"
-reportUnnecessaryCast = "error"
-reportImplicitStringConcatenation = "error"
-
-strictListInference = true
-strictDictionaryInference = true
-strictSetInference = true

--- a/pyright.ci.json
+++ b/pyright.ci.json
@@ -1,6 +1,0 @@
-{
-    "extends": "./pyproject.toml",
-    "ignore": [
-        "src/scadview/ui/wx"
-    ]
-}

--- a/src/scadview/__init__.py
+++ b/src/scadview/__init__.py
@@ -25,16 +25,16 @@ if False:
 
 # Things to expose at the top level
 __all__ = [
-    "Color",  # type: ignore[reportUnsupportedDunderAll]
-    "set_mesh_color",  # type: ignore[reportUnsupportedDunderAll]
-    "ProfileType",  # type: ignore[reportUnsupportedDunderAll]
-    "linear_extrude",  # type: ignore[reportUnsupportedDunderAll]
-    "mesh_from_heightmap",  # type: ignore[reportUnsupportedDunderAll]
-    "surface",  # type: ignore[reportUnsupportedDunderAll]
-    "SIZE_MULTIPLIER",  # type: ignore[reportUnsupportedDunderAll]
-    "text",  # type: ignore[reportUnsupportedDunderAll]
-    "text_polys",  # type: ignore[reportUnsupportedDunderAll]
-    "manifold_to_trimesh",  # type: ignore[reportUnsupportedDunderAll]
+    "Color",
+    "set_mesh_color",
+    "ProfileType",
+    "linear_extrude",
+    "mesh_from_heightmap",
+    "surface",
+    "SIZE_MULTIPLIER",
+    "text",
+    "text_polys",
+    "manifold_to_trimesh",
 ]
 
 # Map attribute names to (module, attribute) so we can lazy-load

--- a/src/scadview/api/linear_extrude.py
+++ b/src/scadview/api/linear_extrude.py
@@ -111,8 +111,7 @@ def _is_list_2dim_2d_or_3d_points(profile: ProfileType) -> bool:
         and (
             all(
                 [
-                    isinstance(vert, (tuple, list))  # type: ignore[reportUnecessaryIsInstance] - want to report to user if incorrect type
-                    and len(vert) in (2, 3)
+                    isinstance(vert, (tuple, list)) and len(vert) in (2, 3)
                     for vert in profile
                 ]
             )
@@ -132,24 +131,20 @@ def _determine_final_scale(
     scale: float | tuple[float, float] | list[float] | NDArray[np.float32],
 ) -> tuple[float, float]:
     if not isinstance(scale, (tuple, list, np.ndarray)):
-        scale = (float(scale), float(scale))
-    return (float(scale[0]), float(scale[1]))
+        return (float(scale), float(scale))
+    # Normalize indexable scale inputs so ty sees a single concrete shape.
+    scale_values = np.asarray(scale, dtype=np.float32).reshape(-1)
+    return (float(scale_values[0]), float(scale_values[1]))
 
 
 def _as_poly_2d(profile: ProfileType) -> sg.Polygon:
     if isinstance(profile, sg.Polygon):
-        poly = profile
-    elif isinstance(profile, np.ndarray):
-        if profile.shape[1] == 3:
-            poly = sg.Polygon(profile[:, :2])
-        else:
-            poly = sg.Polygon(profile)
-    else:
-        if len(profile[0]) == 3:
-            poly = sg.Polygon([p[:2] for p in profile])
-        else:
-            poly = sg.Polygon(profile)
-    return poly
+        return profile
+    # Normalize list/ndarray profiles before slicing 3D points down to XY.
+    points = np.asarray(profile, dtype=np.float32)
+    if points.shape[1] == 3:
+        points = points[:, :2]
+    return sg.Polygon(points)
 
 
 def _orient_polygon_rings(poly: sg.Polygon) -> sg.Polygon:
@@ -325,13 +320,12 @@ def _find_boundary_rings_indexes(
     # map ring vertices -> triangulation indices
     kdt = KDTree(verts_2d)
     # list of array(shape(mi,), intp) where mi is number of vertices in ring i
-    rings_idxs = [  # pyright: ignore[reportUnknownVariableType] - scipy fn
+    rings_idxs = [
         kdt.query(r, k=1)[1] for r in rings
     ]  # list of len(bndries) of array(shape(m,), intp)
     # ensure indices are intp
     rings_idxs = [
-        np.asarray(ri, dtype=np.intp)
-        for ri in rings_idxs  # pyright: ignore[reportUnknownVariableType] - scipy
+        np.asarray(ri, dtype=np.intp) for ri in rings_idxs
     ]  # list of len(bndries) of array(shape(m,), intp)
     return rings_idxs
 

--- a/src/scadview/api/text_builder.py
+++ b/src/scadview/api/text_builder.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 from shapely.geometry import Point, Polygon
 from trimesh import Trimesh
 from trimesh.creation import (
-    extrude_polygon,  # pyright: ignore[reportUnknownVariableType] - trimesh function
+    extrude_polygon,
 )
 
 from scadview.fonts import DEFAULT_FONT, DEFAULT_FONT_PATH, list_system_fonts
@@ -136,7 +136,7 @@ def text(
         text, size, font, halign, valign, spacing, direction, language, script
     )
     meshes = [extrude_polygon(poly, height=1.0) for poly in polys]
-    return trimesh.util.concatenate(meshes)  # pyright: ignore[reportUnknownVariableType] - trimesh function
+    return trimesh.util.concatenate(meshes)
 
 
 def _loops_from_text(
@@ -252,18 +252,13 @@ def _assemble_polys(
         if loops_cont[i]["exterior"]:
             for j in loops_cont[i]["contains"]:
                 # remove contained loops that are also contained in interior loops from the holes list
-                for k in loops_cont[  # pyright: ignore[reportUnknownVariableType] - is Any
-                    j
-                ]["contains"]:
+                for k in loops_cont[j]["contains"]:
                     if k in loops_cont[i]["holes"]:
                         loops_cont[i]["holes"].remove(k)
             polys.append(
                 Polygon(
                     loops[i],
-                    [
-                        loops[j]
-                        for j in loops_cont[i]["holes"]  # type: ignore[reportUnknownArgumentType] can't resolve
-                    ],
+                    [loops[j] for j in loops_cont[i]["holes"]],
                 )
             )
     return polys

--- a/src/scadview/controller.py
+++ b/src/scadview/controller.py
@@ -26,7 +26,7 @@ UNSUPPORTED_EXPORT_FORMATS = ["dict", "dict64", "stl_ascii", "xyz"]
 def export_formats() -> list[str]:
     return [
         fmt
-        for fmt in export._mesh_exporters.keys()  # pyright: ignore[reportPrivateUsage] - only way to access this
+        for fmt in export._mesh_exporters.keys()
         if fmt not in UNSUPPORTED_EXPORT_FORMATS
     ]
 
@@ -108,15 +108,18 @@ class Controller:
         return load_result
 
     def export(self, file_path: str):
-        if not self.current_mesh:
+        # Cache the property so type narrowing is stable for the selected mesh.
+        current_mesh = self.current_mesh
+        if not current_mesh:
             logger.info("No mesh to export")
             return
-        if isinstance(self.current_mesh, list):
-            export_mesh = self.current_mesh[-1]
+        if isinstance(current_mesh, list):
+            export_mesh = current_mesh[-1]
         else:
-            export_mesh = self.current_mesh
+            export_mesh = current_mesh
         self._last_export_path = file_path
-        export_mesh.export(file_path)
+        # Trimesh exposes export at runtime, but its stubs do not model it.
+        export_mesh.export(file_path)  # ty: ignore[unresolved-attribute]
 
     def default_export_path(self) -> str:
         if self._last_export_path != "":

--- a/src/scadview/mesh_loader_process.py
+++ b/src/scadview/mesh_loader_process.py
@@ -53,7 +53,7 @@ class MpQueue(Generic[T]):
         return self._queue.put(item, block=block, timeout=timeout)
 
     def get(self, block: bool = True, timeout: float | None = None) -> T:
-        item = self._queue.get(block=block, timeout=timeout)  # type: ignore[reportUnknowVariableType] - can't resolve
+        item = self._queue.get(block=block, timeout=timeout)
         return self._check_type(item)
 
     def _check_type(self, item: Any) -> T:
@@ -187,14 +187,14 @@ class LoadWorker(Thread):
             return manifold_to_trimesh(mesh)
         if isinstance(mesh, list):
             result: list[Trimesh] = []
-            for m in mesh:  # type: ignore[reportUnknowVariableType] - can't resolve
+            for m in mesh:
                 if isinstance(m, Trimesh):
                     result.append(m)
                 elif isinstance(m, Manifold):
                     result.append(manifold_to_trimesh(m))
                 else:
                     raise TypeError(
-                        f"Expected mesh item to be of type Trimesh or Manifold, got {type(m)}"  # type: ignore[reportUnknowArgumentType] - can't resolve
+                        f"Expected mesh item to be of type Trimesh or Manifold, got {type(m)}"
                     )
             return result
         raise TypeError(
@@ -240,7 +240,7 @@ class LoadWorker(Thread):
             self._check_manifold(mesh)
             return
         if isinstance(mesh, list):
-            for i, m in enumerate(mesh):  # type: ignore[reportUnknowVariableType] - can't resolve
+            for i, m in enumerate(mesh):
                 if isinstance(m, Trimesh):
                     self._check_trimesh_vertices(m)
                     continue
@@ -249,7 +249,7 @@ class LoadWorker(Thread):
                     continue
                 if not isinstance(m, Trimesh) and not isinstance(m, Manifold):
                     raise TypeError(
-                        f"Expected mesh[{i}] to be of type Trimesh or Manifold, got {type(m)}"  # type: ignore[reportUnknowArgumentType] - can't resolve
+                        f"Expected mesh[{i}] to be of type Trimesh or Manifold, got {type(m)}"
                     )
             return
         raise TypeError(

--- a/src/scadview/render/camera.py
+++ b/src/scadview/render/camera.py
@@ -96,11 +96,15 @@ class Camera:
         self.on_program_value_change.notify(ShaderVar.GNOMON_VIEW_MATRIX, gvm)
         return gvm
 
+    # Base Camera is intentionally instantiable; concrete subclasses override this.
     @property
-    def projection_matrix(self) -> NDArray[np.float32]: ...
+    def projection_matrix(self) -> NDArray[np.float32]: ...  # ty: ignore[empty-body]
 
+    # Base Camera is intentionally instantiable; concrete subclasses override this.
     @property
-    def gnomon_projection_matrix(self) -> NDArray[np.float32]: ...
+    def gnomon_projection_matrix(
+        self,
+    ) -> NDArray[np.float32]: ...  # ty: ignore[empty-body]
 
     @property
     def points(self) -> NDArray[np.float32]:
@@ -124,15 +128,13 @@ class Camera:
         """
         # perp_up = self.up
         perp_up = self.perpendicular_up
-        rotated_up_mat = matrix33.create_from_axis_rotation(  # pyright: ignore[reportUnknownVariableType] can't resolve
+        rotated_up_mat = matrix33.create_from_axis_rotation(
             self.direction, angle_from_up, dtype="f4"
         )
         rotated_up = matrix33.apply_to_vector(rotated_up_mat, self.up)
-        rotation_axis = (  # pyright: ignore[reportUnknownVariableType] can't resolve
-            np.cross(self.direction, rotated_up)
-        )
-        rotation = matrix33.create_from_axis_rotation(  # pyright: ignore[reportUnknownVariableType] can't resolve
-            rotation_axis,  # pyright: ignore[reportUnknownArgumentType] - Can't resolve
+        rotation_axis = np.cross(self.direction, rotated_up)
+        rotation = matrix33.create_from_axis_rotation(
+            rotation_axis,
             rotation_angle,
             dtype="f4",
         )

--- a/src/scadview/render/label_renderee.py
+++ b/src/scadview/render/label_renderee.py
@@ -1,6 +1,7 @@
 import logging
 from dataclasses import dataclass
 from math import pi
+from typing import cast
 
 import moderngl
 import numpy as np
@@ -48,9 +49,10 @@ class LabelRenderee(Renderee):
         self._sampler = None
         self._vao = None
 
-        self._program["atlas"].value = (  # pyright: ignore [reportAttributeAccessIssue]
-            self.ATLAS_SAMPLER_LOCATION
-        )
+        # ModernGL returns a union; this shader binding is known to be a uniform.
+        cast(
+            moderngl.Uniform, self._program["atlas"]
+        ).value = self.ATLAS_SAMPLER_LOCATION
         self._translate_to_origin = Matrix44.from_translation(
             [-self._number, 0.0, 0.0], dtype="f4"
         )
@@ -130,9 +132,8 @@ class LabelRenderee(Renderee):
         self._ctx.blend_func = (moderngl.SRC_ALPHA, moderngl.ONE_MINUS_SRC_ALPHA)
         m_base_scale_at_label = self._calc_base_scale_at_label_matrix()
         m_scale = self._calc_scale_matrix_for_axis(m_base_scale_at_label)
-        self._program["m_scale"].write(  # pyright: ignore [reportAttributeAccessIssue]
-            m_scale
-        )
+        # ModernGL returns a union; this shader binding is known to be a uniform.
+        cast(moderngl.Uniform, self._program["m_scale"]).write(m_scale)
         if (
             self._vao is None
         ):  # Create VAO lazily to ensure it is created during the render while the context is active
@@ -151,25 +152,25 @@ class LabelRenderee(Renderee):
 
     def _calc_base_scale_at_label_matrix(self) -> Matrix44:
         m_shift_up = Matrix44.from_translation([0.0, self.shift_up, 0.0], dtype="f4")
-        m_base_scale_at_label = (  # # pyright: ignore[reportUnknownVariableType] can't resolve
+        m_base_scale_at_label = (
             m_shift_up
             * self._translate_from_origin
             * self._m_base_scale
             * self._translate_to_origin
         )
-        return m_base_scale_at_label  # pyright: ignore[reportUnknownVariableType] can't resolve
+        return m_base_scale_at_label
 
     def _calc_scale_matrix_for_axis(self, m_base_scale_at_label: Matrix44) -> Matrix44:
         if self.axis == 0:
             return m_base_scale_at_label
         if self.axis == 1:
             rotation = Matrix44.from_z_rotation(-pi / 2.0, dtype="f4")
-            return rotation * m_base_scale_at_label  # pyright: ignore[reportUnknownVariableType] can't resolve
+            return rotation * m_base_scale_at_label
         if self.axis == 2:
-            rotation = Matrix44.from_z_rotation(  # pyright: ignore[reportUnknownVariableType] can't resolve
+            rotation = Matrix44.from_z_rotation(
                 pi, dtype="f4"
             ) * Matrix44.from_y_rotation(pi / 2.0, dtype="f4")
-            return rotation * m_base_scale_at_label  # pyright: ignore[reportUnknownVariableType] can't resolve
+            return rotation * m_base_scale_at_label
         else:
             raise ValueError(f"Invalid axis value: {self.axis}. Must be 0, 1, or 2.")
 

--- a/src/scadview/render/renderer.py
+++ b/src/scadview/render/renderer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
 import moderngl
 import numpy as np
@@ -7,7 +7,7 @@ from numpy.typing import NDArray
 from pyrr import Matrix44
 from trimesh import Trimesh
 from trimesh.creation import (
-    box,  # pyright: ignore[reportUnknownVariableType] can't resolve
+    box,
 )
 
 from scadview.debug_info import DebugInfoService
@@ -301,7 +301,9 @@ class Renderer:
             name=name,
         )
         if isinstance(mesh, list):
-            self.scale = max([m.scale for m in mesh])
+            # Trimesh stubs are list-like, so make this branch's contract explicit.
+            meshes = cast(list[Trimesh], mesh)
+            self.scale = max([m.scale for m in meshes])
         else:
             self.scale = mesh.scale
         self._main_renderee.subscribe_to_updates(self.on_program_value_change)

--- a/src/scadview/render/shader_program.py
+++ b/src/scadview/render/shader_program.py
@@ -62,7 +62,8 @@ class ShaderProgram:
         uniform = self.program[var_name]
         if not isinstance(uniform, Uniform):
             raise TypeError(f"{var_name!r} is not a uniform")
-        if uniform.gl_type == self.BOOLEAN:  # type: ignore[attr-defined]
+        # ModernGL exposes gl_type at runtime, but its stubs omit it.
+        if uniform.gl_type == self.BOOLEAN:  # ty: ignore[unresolved-attribute]
             uniform.value = value
         else:
             uniform.write(value)

--- a/src/scadview/render/trimesh_renderee.py
+++ b/src/scadview/render/trimesh_renderee.py
@@ -1,12 +1,13 @@
 import logging
 from abc import abstractmethod
+from typing import cast
 
 import moderngl
 import numpy as np
 from numpy.typing import NDArray
 from trimesh import Trimesh
 from trimesh.bounds import (
-    corners,  # pyright: ignore[reportUnknownVariableType] can't resolve
+    corners,
 )
 
 from scadview.observable import Observable
@@ -37,15 +38,9 @@ def create_colors_array_from_mesh(mesh: Trimesh) -> NDArray[np.uint8]:
 
 def get_metadata_color(mesh: Trimesh) -> NDArray[np.uint8]:
     metadata: dict[str, dict[str, list[float]]]
-    metadata = mesh.metadata  # pyright: ignore[reportUnknownVariableType]
-    if (
-        isinstance(metadata, dict)  # pyright: ignore[reportUnnecessaryIsInstance] - needed since ignoring type in line above
-        and "scadview" in metadata
-    ):
-        if (
-            metadata["scadview"] is not None  # pyright: ignore[reportUnnecessaryComparison] - needed since ignoring type above
-            and "color" in metadata["scadview"]
-        ):
+    metadata = mesh.metadata
+    if isinstance(metadata, dict) and "scadview" in metadata:
+        if metadata["scadview"] is not None and "color" in metadata["scadview"]:
             color = metadata["scadview"]["color"]
             if len(color) == 4 and all(isinstance(c, float) for c in color):
                 return convert_color_to_uint8(metadata["scadview"]["color"])
@@ -167,7 +162,8 @@ class TrimeshOpaqueRenderee(TrimeshRenderee):
             self._ctx.disable(moderngl.CULL_FACE)
         self._ctx.enable(moderngl.DEPTH_TEST)
         self._ctx.disable(moderngl.BLEND)
-        self._ctx.depth_mask = True  # type: ignore[attr-defined]
+        # ModernGL exposes depth_mask at runtime, but its stubs omit it.
+        self._ctx.depth_mask = True  # ty: ignore[unresolved-attribute]
         if (
             self._vao is None
         ):  # Lazily create the _vao so that it is created during the render when the context is active
@@ -261,7 +257,8 @@ class AlphaRenderee(Renderee):
         self._ctx.blend_func = (moderngl.SRC_ALPHA, moderngl.ONE_MINUS_SRC_ALPHA)
         self._ctx.enable(moderngl.DEPTH_TEST)
         self._ctx.enable(moderngl.BLEND)
-        self._ctx.depth_mask = False  # type: ignore[attr-defined]
+        # ModernGL exposes depth_mask at runtime, but its stubs omit it.
+        self._ctx.depth_mask = False  # ty: ignore[unresolved-attribute]
         self._vao.render()
 
 
@@ -392,10 +389,12 @@ def create_trimesh_renderee(
     name: str = "Unknown create_trimesh_renderee",
 ) -> TrimeshRenderee:
     if isinstance(mesh, list):
+        # Trimesh stubs are list-like, so make this branch's contract explicit.
+        meshes = cast(list[Trimesh], mesh)
         return create_trimesh_list_renderee(
             ctx,
             program,
-            mesh,
+            meshes,
             model_matrix,
             view_matrix,
             name,

--- a/src/scadview/resources/xyz_cube.py
+++ b/src/scadview/resources/xyz_cube.py
@@ -1,9 +1,9 @@
 import numpy as np
 from pyrr.matrix44 import (
-    create_from_axis_rotation,  # type: ignore[reportUnknownVariableType]
+    create_from_axis_rotation,
 )
 from trimesh import Trimesh
-from trimesh.creation import box  # type: ignore[reportUnknownVariableType]
+from trimesh.creation import box
 
 from scadview import text
 

--- a/src/scadview/ui/splash.py
+++ b/src/scadview/ui/splash.py
@@ -8,7 +8,7 @@ from typing import Any, Protocol
 from scadview.logging_main import log_queue
 from scadview.logging_worker import configure_worker_logging
 from scadview.ui.splash_window import (
-    create_splash_window,  # type: ignore[reportUnknownVariableType]
+    create_splash_window,
 )
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ def _splash_worker(
     """Runs in a separate process: show Tk splash until told to close."""
     configure_worker_logging(log_q, logger.getEffectiveLevel())
     logger.debug("worker starting")
-    root, splash = create_splash_window()  # type: ignore[reportUnknownVariableType]
+    root, splash = create_splash_window()
 
     def check_pipe():
         if conn.poll():

--- a/src/scadview/ui/splash_window.py
+++ b/src/scadview/ui/splash_window.py
@@ -1,9 +1,12 @@
-# type: ignore
-# Ignore types, since we conditionally import tkinter
-# - tkinter may not be available on some systems or python installations
-#
+import logging
+from pathlib import Path
+from typing import Any, Callable
+
+tk: Any
 try:
-    import tkinter as tk
+    import tkinter
+
+    tk = tkinter
 
     tkinter_available = True
 except ImportError:
@@ -20,10 +23,6 @@ except ImportError:
         TclError = Exception
 
     tk = _FakeTk
-
-import logging
-from pathlib import Path
-from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -52,14 +51,14 @@ class NullSplash:
         pass
 
 
-def create_splash_window() -> tuple[tk.Tk | NullRoot, tk.Toplevel | NullSplash]:
+def create_splash_window() -> tuple[Any, Any]:
     """Create and show the splash window."""
     logger.warning(f"***** {MESSAGE_TEXT} *****")
     if not tkinter_available:
         logger.warning("The splash screen is not available so it will not be shown.")
         return NullRoot(), NullSplash()
     root = _create_tk_root()
-    splash = tk.Toplevel(root)  # type: ignore[reportOptionalCall]
+    splash = tk.Toplevel(root)
     splash.overrideredirect(True)
 
     try:
@@ -82,7 +81,7 @@ def create_splash_window() -> tuple[tk.Tk | NullRoot, tk.Toplevel | NullSplash]:
     return root, splash
 
 
-def _create_tk_root() -> tk.Tk:
+def _create_tk_root() -> Any:
     # Hidden root; splash is a Toplevel
     # On Windows, can't seem to use the root as the splash
     root = tk.Tk()
@@ -90,20 +89,20 @@ def _create_tk_root() -> tk.Tk:
     return root
 
 
-def _create_frame(parent: tk.Tk | tk.Toplevel) -> tk.Frame:  #
-    frame = tk.Frame(parent, bg="white", padx=20, pady=20)  # type: ignore[reportUnknownVariableType]
+def _create_frame(parent: Any) -> Any:
+    frame = tk.Frame(parent, bg="white", padx=20, pady=20)
     frame.pack()
     return frame
 
 
-def _add_title(frame: tk.Frame) -> None:
+def _add_title(frame: Any) -> None:
     title_label = tk.Label(
         frame, text=TITLE_TEXT, font=("Helvetica", 20, "bold"), bg="white", fg="#333"
     )
     title_label.pack(pady=(0, 10))
 
 
-def _add_message(frame: tk.Frame) -> None:
+def _add_message(frame: Any) -> None:
     message_label = tk.Label(
         frame,
         text=MESSAGE_TEXT,
@@ -116,7 +115,7 @@ def _add_message(frame: tk.Frame) -> None:
     message_label.pack(pady=(0, 12))
 
 
-def _add_image(window: tk.Tk | tk.Toplevel, image_path: str, frame: tk.Frame) -> None:
+def _add_image(window: Any, image_path: str, frame: Any) -> None:
     if not Path(image_path).is_file():
         logger.warning(f"splash image not found at {image_path}")
         return
@@ -128,12 +127,12 @@ def _add_image(window: tk.Tk | tk.Toplevel, image_path: str, frame: tk.Frame) ->
         return
 
     # Keep reference to avoid garbage collection
-    window._splash_image = img
+    setattr(window, "_splash_image", img)
     img_label = tk.Label(frame, image=img, bg="white")
     img_label.pack()
 
 
-def _center_window(win: tk.Tk | tk.Toplevel) -> None:
+def _center_window(win: Any) -> None:
     win.update_idletasks()
     w = win.winfo_width()
     h = win.winfo_height()

--- a/src/scadview/ui/wx/gl_ui.py
+++ b/src/scadview/ui/wx/gl_ui.py
@@ -38,9 +38,10 @@ class GlUi:
 
     def _bring_to_front_mac(self):
         try:
-            from AppKit import NSApplication  # type: ignore[reportAttributeAccessIssue]
+            # pyobjc exposes this member at runtime, but ty cannot resolve it.
+            from AppKit import NSApplication  # ty: ignore[unresolved-import]
 
-            app = NSApplication.sharedApplication()  # type: ignore[reportUnknownVariableType]
+            app = NSApplication.sharedApplication()
             app.activateIgnoringOtherApps_(True)
         except Exception:
             pass

--- a/src/scadview/ui/wx/gl_widget.py
+++ b/src/scadview/ui/wx/gl_widget.py
@@ -99,13 +99,11 @@ class GlWidget(GLCanvas):
         del dc
         self.SetCurrent(self.ctx_wx)
         self._sync_pixel_size()
-        size = self.GetClientSize()  # pyright: ignore[reportUnknownVariableType]
-        scale = (  # pyright: ignore[reportUnknownVariableType]
-            self.GetContentScaleFactor()
-        )
+        size = self.GetClientSize()
+        scale = self.GetContentScaleFactor()
         self._gl_widget_adapter.render(
-            scale * size.width,  # pyright: ignore[reportUnknownArgumentType]
-            scale * size.height,  # pyright: ignore[reportUnknownArgumentType]
+            scale * size.width,
+            scale * size.height,
         )
         self.SwapBuffers()
         logger.debug("on_paint end")
@@ -136,11 +134,11 @@ class GlWidget(GLCanvas):
         self.Refresh(False)
 
     def _sync_pixel_size(self, force: bool = False):
-        size: wx.Size = self.GetClientSize()  # pyright: ignore[reportUnknownVariableType]
-        scale = self.GetContentScaleFactor()  # pyright: ignore[reportUnknownVariableType]
+        size: wx.Size = self.GetClientSize()
+        scale = self.GetContentScaleFactor()
         pixel_size = (
-            int(scale * size.width),  # pyright: ignore[reportUnknownArgumentType]
-            int(scale * size.height),  # pyright: ignore[reportUnknownArgumentType]
+            int(scale * size.width),
+            int(scale * size.height),
         )
         if force or self._last_pixel_size != pixel_size:
             self._gl_widget_adapter.resize(pixel_size[0], pixel_size[1])
@@ -148,12 +146,10 @@ class GlWidget(GLCanvas):
 
     def _get_scaled_position(self, event: wx.MouseEvent) -> wx.Point:
         pos = event.GetPosition()
-        device_scale = (  # pyright: ignore[reportUnknownVariableType]
-            self.GetContentScaleFactor()
-        )
+        device_scale = self.GetContentScaleFactor()
         return wx.Point(
-            int(pos.x * device_scale),  # pyright: ignore[reportUnknownArgumentType]
-            int(pos.y * device_scale),  # pyright: ignore[reportUnknownArgumentType]
+            int(pos.x * device_scale),
+            int(pos.y * device_scale),
         )
 
     def on_mouse_move(self, event: wx.MouseEvent):

--- a/src/scadview/ui/wx/main_frame.py
+++ b/src/scadview/ui/wx/main_frame.py
@@ -222,11 +222,9 @@ class MainFrame(wx.Frame):
             "Load a python file",
             wildcard="Python files (*.py)|*.py",
             style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
-        ) as dlg:  # pyright: ignore[reportUnknownVariableType]
+        ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
-                self._controller.load_mesh(
-                    dlg.GetPath()  # pyright: ignore[reportUnknownArgumentType]
-                )
+                self._controller.load_mesh(dlg.GetPath())
                 self._loader_timer.Start(LOAD_CHECK_INTERVAL_MS)
                 self._load_progress_gauge.Pulse()
 
@@ -276,12 +274,10 @@ class MainFrame(wx.Frame):
             defaultFile=default_export_file,
             wildcard=wildcard,
             style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
-        ) as dlg:  # pyright: ignore[reportUnknownVariableType]
+        ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
                 try:
-                    self._controller.export(
-                        dlg.GetPath()  # pyright: ignore[reportUnknownArgumentType]
-                    )
+                    self._controller.export(dlg.GetPath())
                 except Exception as e:
                     logger.error(f"Failure on export: {e}")
 

--- a/tasks.py
+++ b/tasks.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from invoke.context import Context
 from invoke.exceptions import Exit
-from invoke.tasks import task  # type: ignore[reportUnknownVariableType]
+from invoke.tasks import task
 
 REPO_ROOT: Path = Path(__file__).resolve().parent
 DEFAULT_TARGETS: tuple[str, ...] = ("src", "tests", "examples")
@@ -60,7 +60,7 @@ def _resolve_docs_version(context: Context, override: str = "") -> str:
     return "dev"
 
 
-@task(name="write_stamp")  # type: ignore[reportUntypedFunctionDecorator]
+@task(name="write_stamp")
 def write_stamp(_context: Context, task_name: str) -> None:
     """Write a mise freshness stamp file for a task name."""
     MISE_STAMP_DIR.mkdir(parents=True, exist_ok=True)
@@ -84,7 +84,7 @@ def bootstrap(context: Context, ci: bool = False, frozen: bool = True) -> None:
     _run_checked(context, " ".join(cmd_parts))
 
 
-@task(name="format")  # type: ignore[reportUntypedFunctionDecorator]
+@task(name="format")
 def format_(context: Context, args: str = "") -> None:
     """Format source, tests, and examples."""
     targets: list[str] = _existing_targets()
@@ -115,12 +115,12 @@ def lint(context: Context, args: str = "") -> None:
     _run_checked(context, f"ruff check --select I{extra} {target_str}")
 
 
-@task(name="type")  # type: ignore[reportUntypedFunctionDecorator]
+@task(name="type")
 def type_(context: Context, args: str = "", ci: bool = False) -> None:
-    """Run pyright type checks."""
+    """Run ty type checks."""
     extra: str = _join_args(args)
-    project_flag: str = " --project pyright.ci.json" if ci else ""
-    _run_checked(context, f"pyright{project_flag}{extra}")
+    ci_flags: str = " --exclude src/scadview/ui/wx --force-exclude" if ci else ""
+    _run_checked(context, f"ty check{ci_flags}{extra}")
 
 
 @task
@@ -156,13 +156,13 @@ def run(context: Context, args: str = "") -> None:
     _run_checked(context, f"python -m scadview{extra}")
 
 
-@task(name="docs_live_serve")  # type: ignore[reportUntypedFunctionDecorator]
+@task(name="docs_live_serve")
 def docs_live_serve(context: Context) -> None:
     """Serve docs with live reload (mkdocs)."""
     _run_checked(context, "python -m mkdocs serve")
 
 
-@task(name="docs_sync")  # type: ignore[reportUntypedFunctionDecorator]
+@task(name="docs_sync")
 def docs_sync(
     context: Context,
     serve: bool = False,
@@ -183,7 +183,7 @@ def docs_sync(
         _run_checked(context, "mike serve")
 
 
-@task(name="docs_sync_serve")  # type: ignore[reportUntypedFunctionDecorator]
+@task(name="docs_sync_serve")
 def docs_sync_serve(context: Context, docs_version: str = "") -> None:
     """Preview release docs locally."""
     docs_sync(context, serve=True, docs_version=docs_version)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -842,15 +842,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "numpy"
 version = "2.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1075,19 +1066,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyright"
-version = "1.1.408"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
-]
-
-[[package]]
 name = "pyrr"
 version = "0.10.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1246,7 +1224,7 @@ wheels = [
 
 [[package]]
 name = "scadview"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "manifold3d" },
@@ -1255,7 +1233,6 @@ dependencies = [
     { name = "numpy" },
     { name = "pillow" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyright" },
     { name = "pyrr" },
     { name = "scipy" },
     { name = "shapely" },
@@ -1274,11 +1251,11 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings-python" },
     { name = "pymdown-extensions" },
-    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "watchdog" },
 ]
 taskrunner = [
@@ -1293,7 +1270,6 @@ requires-dist = [
     { name = "numpy", specifier = "==2.*" },
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyright", specifier = ">=1.1.408" },
     { name = "pyrr", specifier = ">=0.10.3" },
     { name = "scipy", specifier = ">=1.16.1" },
     { name = "shapely", specifier = ">=2.1.1" },
@@ -1312,11 +1288,11 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.6.22" },
     { name = "mkdocstrings-python", specifier = ">=1.18.2" },
     { name = "pymdown-extensions", specifier = ">=10.16.1" },
-    { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = ">=0.9.2" },
+    { name = "ty", specifier = ">=0.0.31" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
 taskrunner = [{ name = "invoke", specifier = ">=2.2.0" }]
@@ -1491,12 +1467,27 @@ wheels = [
 ]
 
 [[package]]
-name = "typing-extensions"
-version = "4.15.0"
+name = "ty"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/7e/2aa791c9ae7b8cd5024cd4122e92267f664ca954cea3def3211919fa3c1f/ty-0.0.32.tar.gz", hash = "sha256:8743174c5f920f6700a4a0c9de140109189192ba16226884cd50095b43b8a45c", size = 5522294, upload-time = "2026-04-20T19:29:01.626Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/62/eb/1075dc6a49d7acbe2584ae4d5b410c41b1f177a5adcc567e09eca4c69000/ty-0.0.32-py3-none-linux_armv6l.whl", hash = "sha256:dacbc2f6cd698d488ae7436838ff929570455bf94bfa4d9fe57a630c552aff83", size = 10902959, upload-time = "2026-04-20T19:28:31.907Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d2/c35fc8bc66e98d1ee9b0f8ed319bf743e450e1f1e997574b178fab75670f/ty-0.0.32-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914bbc4f605ce2a9e2a78982e28fae1d3359a169d141f9dc3b4c7749cd5eca81", size = 10726172, upload-time = "2026-04-20T19:28:44.765Z" },
+    { url = "https://files.pythonhosted.org/packages/96/32/c827da3ca480456fb02d8cea68a2609273b6c220fea0be9a4c8d8470b86e/ty-0.0.32-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4787ac9fe1f86b1f3133f5c6732adbe2df5668b50c679ac6e2d98cd284da812f", size = 10163701, upload-time = "2026-04-20T19:28:27.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9e/2734478fbdb90c160cb2813a3916a16a2af5c1e231f87d635f6131d781fb/ty-0.0.32-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8ea0a728af99fe40dd744cba6441a2404f80b7f4bde17aa6da393810af5ea57", size = 10656220, upload-time = "2026-04-20T19:29:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9f/0007da2d35e424debe7e9f86ffbc1ab7f60983cfbc5f0411324ab2de5292/ty-0.0.32-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2850561f9b018ae33d7e5bbfa0ac414d3c518513edcffe43877dc9801446b9c5", size = 10696086, upload-time = "2026-04-20T19:28:46.829Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5e/ce5fd4ec803222ae3e69a76d2a2db2eed55e19f5b131702b9789ef45f93d/ty-0.0.32-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5fa2fb3c614349ee211d36476b49d88c5ef79a687cdb91b2872ad023b94d2f8", size = 11184800, upload-time = "2026-04-20T19:28:42.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/46/ebcf67a5999421331214aac51a7464db42de2be15bbe929c612a3ed0b039/ty-0.0.32-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b89969307ab2417d41c9be8059dd79feea577234e1e10d35132f5495e0d42c6", size = 11718718, upload-time = "2026-04-20T19:28:36.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/2141c86ed0ce0962b45cefb658a95e734f59759d47f20afdcd9c732910a1/ty-0.0.32-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b59868ede9b1d69a088f0d695df52a0061f95fa7baa1d5e0dc6fc9cf06e1334", size = 11346369, upload-time = "2026-04-20T19:28:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/ed6f772339cf29bd9a46def9d6db5084689eb574ee4d150ff704224c1ed8/ty-0.0.32-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8300caf35345498e9b9b03e550bba03cee8f5f5f8ab4c83c3b1ff1b7403b7d3a", size = 11280714, upload-time = "2026-04-20T19:28:51.516Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/c6813987edf4816a40e0c8e408b555f97d3f267c7b3a1688c8bbdf65609c/ty-0.0.32-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:583c7094f4574b02f724db924f98b804d1387a0bd9405ecb5e078cc0f47fbcfb", size = 10638806, upload-time = "2026-04-20T19:28:29.651Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d4/0cefcbd2ad0f3d51762ccf58e652ec7da146eb6ae34f87228f6254bbb8be/ty-0.0.32-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e44ebe1bb4143a5628bc4db67ac0dfebe14594af671e4ee66f6f2e983da56501", size = 10726106, upload-time = "2026-04-20T19:29:06.3Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ad/2c8a97f91f06311f4367400f7d13534bbda2522c73c99a3e4c0757dff9b8/ty-0.0.32-py3-none-musllinux_1_2_i686.whl", hash = "sha256:06f17ada3e069cba6148342ef88e9929156beca8473e8d4f101b68f66c75643e", size = 10872951, upload-time = "2026-04-20T19:28:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/68/42293f9248106dd51875120971a5cc6ea315c2c4dcfb8e59aa063aa0af26/ty-0.0.32-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e96e60fa556cec04f15d7ea62d2ceee5982bd389233e961ab9fd42304e278175", size = 11363334, upload-time = "2026-04-20T19:28:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/df/92/be9abf4d3e589ad5023e2ea965b93e204ec856420d46adf73c5c36c04678/ty-0.0.32-py3-none-win32.whl", hash = "sha256:2ff2ebb4986b24aebcf1444db7db5ca41b36086040e95eea9f8fb851c11e805c", size = 10260689, upload-time = "2026-04-20T19:28:56.541Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/dc86acea899349d2579cb8419aecedd83dc504d7d6a10df65eef546c8300/ty-0.0.32-py3-none-win_amd64.whl", hash = "sha256:ba7284a4a954b598c1b31500352b3ec1f89bff533825592b5958848226fdc7ee", size = 11255371, upload-time = "2026-04-20T19:28:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/43/01/beffec56d71ca25b343ede63adb076456b5b3e211f1c066452a44cd120b3/ty-0.0.32-py3-none-win_arm64.whl", hash = "sha256:7e10aadbdbda989a7d567ee6a37f8b98d4d542e31e3b190a2879fd581f75d658", size = 10658087, upload-time = "2026-04-20T19:28:59.286Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# SCADview Pull Request

---

## Summary

**Issue # (__required__):**
Resolves #120

Replace pyright with ty for project type checking, including local tasks and CI.
The ty configuration reports unnecessary ignore comments as errors, and existing
pyright-specific suppressions were removed or replaced with narrower ty
suppressions only where needed.

---

## Description of Changes

- Replaced pyright with ty in `pyproject.toml`, `uv.lock`, invoke tasks, mise
  tasks, and CI.
- Deleted `pyright.ci.json`; CI now passes the wx exclusion directly to
  `ty check` because CI does not install `wxpython`.
- Configured ty to check `src/scadview` and `tasks.py`, and to error on unused
  ignore comments.
- Removed obsolete pyright and type-ignore comments throughout the codebase.
- Added narrow `ty: ignore[...]` comments only for documented third-party stub
  gaps or intentionally empty base-class placeholders.
- Added comments explaining every remaining ty ignore and type-directed cast or
  narrowing change.
- Made small type-directed code adjustments where reviewed and accepted:
  normalized `linear_extrude` scale/profile inputs for ty-visible indexing,
  cached `Controller.current_mesh` for stable narrowing, used `typing.cast` for
  known ModernGL uniforms and Trimesh list branches, and narrowed the previous
  `splash_window.py` file-wide ignore to a dynamic tkinter alias.

---

## Testing

- [ ] Not applicable

- `uv run --no-sync ty check --output-format concise`
- `uv run --no-sync ty check --exclude src/scadview/ui/wx --force-exclude --output-format concise`
- `uv run --no-sync ruff check src tests examples tasks.py`
- `uv run --no-sync ruff format src tests examples tasks.py`
- `uv run --no-sync pytest --color=yes`

Result: `237 passed, 1 skipped`.

---

## Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings
- [ ] I updated or added relevant documentation in `/docs`
- [x] Not applicable

---

## Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)
- [x] No

---

## Additional Notes

- ty is currently resolved to `0.0.32`; checker behavior may evolve while ty is
  still early-versioned.
- The migration does not attempt a one-for-one recreation of every pyright
  strictness setting. It enables ty checking and explicitly enforces unused
  ignore hygiene as requested.
- Remaining `ty: ignore[...]` comments are intentionally narrow and documented
  inline.

---

## Checklist

Before requesting review, confirm the following:

- [x] The code follows SCADview's coding standards (PEP 8, type hints, etc.).
- [x] I have run `mise preflight` and all stages pass
- [x] My changes include or update tests where appropriate.
- [x] I have updated documentation where needed.
- [x] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [x] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
