### PR TITLE
[feat] add toggleable mesh features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,9 @@ If guidance conflicts, follow this precedence:
 - Treat `pyproject.toml`, GitHub Actions, and docs as user-facing interfaces.
 - Keep changes reproducible and minimal.
 - Do not modify release, publishing, or deployment behavior without explicitly stating it.
+- When creating GitHub issues, use the matching issue template from
+  `.github/ISSUE_TEMPLATE/` and apply only labels that already exist in the
+  repository.
 - When creating or updating a pull request, use the repository PR template at
   `.github/pull_request_template.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,33 @@ If guidance conflicts, follow this precedence:
 
 ---
 
+## API Design
+
+- Keep public user-facing APIs small and explicit.
+- Expose public helpers through `src/scadview/api/*` and the top-level lazy
+  exports in `src/scadview/__init__.py` when appropriate.
+- Prefer name-level state over per-instance state when UI controls represent
+  shared concepts.
+- For unreleased APIs, prefer clear internal models over preserving accidental
+  compatibility from intermediate branches or PR iterations.
+- Do not expand the documented `create_mesh` return contract unless the user
+  explicitly asks for that public API change.
+- When adding or changing public behavior, update tests, docs, and examples in
+  the same change when practical.
+
+---
+
+## Feature Capability
+
+- Feature enabled/disabled state is name-level and controlled by `FeatureState`.
+- `feature_default(...)` defines module defaults; controller and UI overrides
+  take precedence.
+- Keep boolean mesh wrappers internal unless a public API change is explicitly
+  requested.
+- Do not conflate feature inclusion state with visualization or debug modes.
+
+---
+
 ## Change Strategy
 
 - Inspect first, then propose changes, then implement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ If guidance conflicts, follow this precedence:
 - Treat `pyproject.toml`, GitHub Actions, and docs as user-facing interfaces.
 - Keep changes reproducible and minimal.
 - Do not modify release, publishing, or deployment behavior without explicitly stating it.
+- When creating or updating a pull request, use the repository PR template at
+  `.github/pull_request_template.md`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,9 @@ mise run reset
 - **Follow coding standards**, as documented `STYLE.md`
 - Add or update tests where appropriate
 - Update documentation if public behavior or APIs change
+- When changing a public API, update the relevant docs and examples in the same
+  PR when practical, so users can see both the reference behavior and usage
+  pattern.
 
 #### Documentation Workflow (Versioned Docs)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,6 +258,16 @@ ci: | GitHub Actions / CI | Patch
 
 Before submitting your PR, ensure your changes pass all local checks:
 
+### 8. Open the Pull Request
+
+When creating or updating a PR, use the repository PR template in:
+
+```text
+.github/pull_request_template.md
+```
+
+Make sure the PR body is filled out rather than replaced with an ad hoc summary.
+
 - Formatting
 - Linting
 - Type checks (if applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,16 +258,6 @@ ci: | GitHub Actions / CI | Patch
 
 Before submitting your PR, ensure your changes pass all local checks:
 
-### 8. Open the Pull Request
-
-When creating or updating a PR, use the repository PR template in:
-
-```text
-.github/pull_request_template.md
-```
-
-Make sure the PR body is filled out rather than replaced with an ad hoc summary.
-
 - Formatting
 - Linting
 - Type checks (if applicable)

--- a/README.md
+++ b/README.md
@@ -109,13 +109,19 @@ features like this:
 
 ```python
 from trimesh.creation import box
-from scadview import feature
+from scadview import feature, feature_default
+
+
+feature_default("guide", enabled=False)
 
 
 @feature
 def guide():
     return box([20, 10, 8])
 ```
+
+Features are enabled by default. `feature_default(...)` sets the initial state
+for a feature name when no UI override exists.
 
 Save the file:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ SCADview enables a iterative work flow to build Trimesh objects.
 1.  Reload and view the modified mesh.
 1.  Repeat the edits and reloads.
 
+Optional geometry can also be exposed as UI-togglable features by decorating
+mesh-returning functions or methods with `scadview.feature(...)`.
+
 ## Getting Started
 
 ### Installation
@@ -100,6 +103,19 @@ def create_mesh():
 ```
 
 Notice that you don't need to import the scadview package.
+
+If you want to expose optional parts of your model in the UI, you can define
+features like this:
+
+```python
+from trimesh.creation import box
+from scadview import feature
+
+
+@feature
+def guide():
+    return box([20, 10, 8])
+```
 
 Save the file:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,6 +3,7 @@
 ::: scadview.Color
 ::: scadview.set_mesh_color
 ::: scadview.feature
+::: scadview.feature_default
 ::: scadview.surface
 ::: scadview.mesh_from_heightmap
 ::: scadview.SIZE_MULTIPLIER

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,7 @@
 
 ::: scadview.Color
 ::: scadview.set_mesh_color
+::: scadview.feature
 ::: scadview.surface
 ::: scadview.mesh_from_heightmap
 ::: scadview.SIZE_MULTIPLIER

--- a/docs/create_mesh.md
+++ b/docs/create_mesh.md
@@ -36,6 +36,61 @@ But `manifold3d` is highly optimized for geometric boolean operations,
 and can be much faster than Trimesh.
 So if you are combining 100s of meshes, consider trying out `manifold3d`.
 
+## Toggleable Features
+
+{{ project_name }} can expose optional geometry as UI-togglable features.
+Use [`feature`](api.md#{{ package_name }}.feature) on a mesh-returning function
+or method:
+
+```python
+from trimesh.creation import box, cylinder
+
+from scadview import feature
+
+
+@feature
+def guide():
+    return box([20, 10, 8])
+
+
+@feature("cutout")
+def cutout():
+    return cylinder(radius=3, height=20)
+```
+
+You can also wrap a mesh directly with `feature("name", mesh)`:
+
+```python
+from trimesh.creation import box
+
+from scadview import feature
+
+
+def create_mesh():
+    base = box([40, 20, 10])
+    guide = feature("guide", box([20, 10, 8]))
+    return base.union(guide)
+```
+
+Feature-decorated functions and methods must return a `Trimesh` or `Manifold`.
+Decorating classes is not supported.
+
+Disabled features behave like identity operands for supported boolean operations:
+
+- `Trimesh`: `union(...)`, `difference(...)`, `intersection(...)`
+- `Manifold`: `+`, `-`, `^`
+
+That lets you write expressions such as:
+
+```python
+def create_mesh():
+    base = box([40, 20, 10])
+    return base.union(guide()).difference(cutout())
+```
+
+When the script is loaded, each discovered feature appears in the UI and can be
+toggled on or off without editing the script.
+
 ## Debug Mode: Return a `list`
 
 Returning a `list` of objects results in {{ project_name }}

--- a/docs/create_mesh.md
+++ b/docs/create_mesh.md
@@ -91,6 +91,31 @@ def create_mesh():
 When the script is loaded, each discovered feature appears in the UI and can be
 toggled on or off without editing the script.
 
+Features are enabled by default. Use
+[`feature_default`](api.md#{{ package_name }}.feature_default) to make a named
+feature start disabled when no UI override exists:
+
+```python
+from trimesh.creation import box
+
+from scadview import feature, feature_default
+
+
+feature_default("supports", enabled=False)
+
+
+def create_mesh():
+    base = box([40, 20, 10])
+    support_a = feature("supports", box([4, 4, 20]))
+    support_b = feature("supports", box([4, 4, 20]))
+    return base.union(support_a).union(support_b)
+```
+
+Defaults apply by feature name, so every mesh registered as `"supports"` uses the
+same default. If the UI has already toggled a feature, that UI state takes
+precedence over the script default. Repeating the same default is allowed, but
+declaring conflicting defaults for the same feature name raises `ValueError`.
+
 ## Debug Mode: Return a `list`
 
 Returning a `list` of objects results in {{ project_name }}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -63,6 +63,22 @@ Creates a lovely red heart vase.
 </details>
 ![Heart Vase](images/heart_vase.png)
 
+## features.py
+
+Shows the feature API in one compact model: `feature(...)` as a decorator,
+directly wrapping a mesh, `feature_default(...)`, and multiple meshes sharing the
+same feature name.
+
+<details>
+<summary>Source</summary>
+
+```python
+
+{% include "../examples/features.py" %}
+
+```
+</details>
+
 ## invalid_code.py
 
 Imports a non-existent module to force an import error. Useful for verifying error handling.

--- a/docs/user_interface.md
+++ b/docs/user_interface.md
@@ -12,6 +12,9 @@ you complete them.
   button to pick a Python file that defines `create_mesh`.
 - If you want to re-run the last script after edits, use `File > Reload` or the
   `Reload` button.
+- If your script uses `scadview.feature(...)`, the right sidebar shows a
+  `Features` section with one checkbox per discovered feature. Toggle a feature
+  to reload the script with that optional geometry enabled or disabled.
 - If you want to export the current mesh, use `File > Export...` or the `Export`
   button. Export is enabled only after a load completes.
 - If an export format reports a missing dependency, install the package named
@@ -58,6 +61,8 @@ you complete them.
 
 - If you want to see loading progress, watch the right-side progress bar. It
   pulses while loading and fills when complete.
+- If your script defines many features, the `Features` section scrolls
+  independently so the lower sidebar controls remain visible.
 - The viewport background color also provides status:
     - Blue: currently loading
     - Green: loaded successfully

--- a/examples/features.py
+++ b/examples/features.py
@@ -1,0 +1,30 @@
+from trimesh.creation import box, cylinder
+
+from scadview import feature, feature_default
+
+feature_default("supports", enabled=False)
+
+
+@feature("cutout")
+def cable_cutout():
+    return cylinder(radius=4.0, height=24.0).apply_translation([0.0, 0.0, 6.0])
+
+
+def create_mesh():
+    base = box([48.0, 24.0, 8.0])
+    handle = feature(
+        "handle", box([18.0, 8.0, 18.0]).apply_translation([0.0, 0.0, 13.0])
+    )
+
+    support_a = feature(
+        "supports",
+        box([4.0, 4.0, 20.0]).apply_translation([-18.0, -8.0, 14.0]),
+    )
+    support_b = feature(
+        "supports",
+        box([4.0, 4.0, 20.0]).apply_translation([18.0, -8.0, 14.0]),
+    )
+
+    return (
+        base.union(handle).union(support_a).union(support_b).difference(cable_cutout())
+    )

--- a/mise.toml
+++ b/mise.toml
@@ -87,8 +87,8 @@ description = "Lint GitHub workflows"
 run = "actionlint -color"
 
 [tasks.preflight]
-description = "Run lint, types, and tests"
-depends = ["lint", "type", "test"]
+description = "Run format, lint, types, and tests"
+depends = ["format", "lint", "type", "test"]
 
 [tasks.reset]
 description = "Reset the development environment"

--- a/src/scadview/__init__.py
+++ b/src/scadview/__init__.py
@@ -7,7 +7,7 @@ if False:
         Color,
         set_mesh_color,
     )
-    from scadview.api.features import feature
+    from scadview.api.features import feature, feature_default
     from scadview.api.linear_extrude import (
         ProfileType,
         linear_extrude,
@@ -29,6 +29,7 @@ __all__ = [
     "Color",
     "set_mesh_color",
     "feature",
+    "feature_default",
     "ProfileType",
     "linear_extrude",
     "mesh_from_heightmap",
@@ -44,6 +45,7 @@ _lazy_map = {
     "Color": ("scadview.api.colors", "Color"),
     "set_mesh_color": ("scadview.api.colors", "set_mesh_color"),
     "feature": ("scadview.api.features", "feature"),
+    "feature_default": ("scadview.api.features", "feature_default"),
     "ProfileType": ("scadview.api.linear_extrude", "ProfileType"),
     "linear_extrude": ("scadview.api.linear_extrude", "linear_extrude"),
     "mesh_from_heightmap": ("scadview.api.surface", "mesh_from_heightmap"),

--- a/src/scadview/__init__.py
+++ b/src/scadview/__init__.py
@@ -7,6 +7,7 @@ if False:
         Color,
         set_mesh_color,
     )
+    from scadview.api.features import feature
     from scadview.api.linear_extrude import (
         ProfileType,
         linear_extrude,
@@ -27,6 +28,7 @@ if False:
 __all__ = [
     "Color",
     "set_mesh_color",
+    "feature",
     "ProfileType",
     "linear_extrude",
     "mesh_from_heightmap",
@@ -41,6 +43,7 @@ __all__ = [
 _lazy_map = {
     "Color": ("scadview.api.colors", "Color"),
     "set_mesh_color": ("scadview.api.colors", "set_mesh_color"),
+    "feature": ("scadview.api.features", "feature"),
     "ProfileType": ("scadview.api.linear_extrude", "ProfileType"),
     "linear_extrude": ("scadview.api.linear_extrude", "linear_extrude"),
     "mesh_from_heightmap": ("scadview.api.surface", "mesh_from_heightmap"),

--- a/src/scadview/api/features.py
+++ b/src/scadview/api/features.py
@@ -11,6 +11,7 @@ from trimesh import Trimesh
 
 from scadview.features import FeatureMesh
 from scadview.features import feature as _feature
+from scadview.features import feature_default as _feature_default
 
 P = ParamSpec("P")
 TNativeMesh = TypeVar("TNativeMesh", Trimesh, Manifold)
@@ -61,3 +62,18 @@ def feature(
         Callable[P, FeatureMesh],
         _feature(name_or_func),
     )
+
+
+def feature_default(name: str, enabled: bool = True) -> None:
+    """Set the default enabled state for a named feature.
+
+    Controller/UI overrides take precedence over module-declared defaults.
+
+    Args:
+        name: Feature name shown in the UI.
+        enabled: Default enabled state when no controller/UI override exists.
+
+    Raises:
+        ValueError: If the same feature name is given conflicting defaults.
+    """
+    _feature_default(name, enabled)

--- a/src/scadview/api/features.py
+++ b/src/scadview/api/features.py
@@ -1,0 +1,62 @@
+"""Feature mesh helpers.
+
+Use features to mark optional geometry that SCADview can toggle in the UI.
+Apply the decorator to mesh-returning functions or methods, not classes.
+"""
+
+from typing import Callable, ParamSpec, TypeVar, cast, overload
+
+from manifold3d import Manifold
+from trimesh import Trimesh
+
+from scadview.features import FeatureMesh, feature as _feature
+
+P = ParamSpec("P")
+TNativeMesh = TypeVar("TNativeMesh", Trimesh, Manifold)
+
+
+@overload
+def feature(name: str, mesh: TNativeMesh) -> FeatureMesh: ...
+
+
+@overload
+def feature(func: Callable[P, TNativeMesh]) -> Callable[P, FeatureMesh]: ...
+
+
+@overload
+def feature(
+    name: str,
+) -> Callable[[Callable[P, TNativeMesh]], Callable[P, FeatureMesh]]: ...
+
+
+def feature(
+    name_or_func: str | Callable[P, TNativeMesh],
+    mesh: TNativeMesh | None = None,
+) -> (
+    FeatureMesh
+    | Callable[P, FeatureMesh]
+    | Callable[[Callable[P, TNativeMesh]], Callable[P, FeatureMesh]]
+):
+    """Mark a mesh or mesh-returning function or method as a named feature.
+
+    Args:
+        name_or_func: Feature name shown in the UI, or a decorated mesh factory.
+        mesh: Mesh controlled by the feature toggle when calling the function form.
+
+    Returns:
+        A feature mesh proxy, or a decorator that wraps a mesh-producing
+        function or method.
+    """
+    if mesh is not None:
+        if not isinstance(name_or_func, str):
+            raise TypeError("Expected feature name to be a string")
+        return _feature(name_or_func, mesh)
+    if isinstance(name_or_func, str):
+        return cast(
+            Callable[[Callable[P, TNativeMesh]], Callable[P, FeatureMesh]],
+            _feature(name_or_func),
+        )
+    return cast(
+        Callable[P, FeatureMesh],
+        _feature(name_or_func),
+    )

--- a/src/scadview/api/features.py
+++ b/src/scadview/api/features.py
@@ -9,7 +9,8 @@ from typing import Callable, ParamSpec, TypeVar, cast, overload
 from manifold3d import Manifold
 from trimesh import Trimesh
 
-from scadview.features import FeatureMesh, feature as _feature
+from scadview.features import FeatureMesh
+from scadview.features import feature as _feature
 
 P = ParamSpec("P")
 TNativeMesh = TypeVar("TNativeMesh", Trimesh, Manifold)

--- a/src/scadview/controller.py
+++ b/src/scadview/controller.py
@@ -5,6 +5,7 @@ import queue
 from trimesh import Trimesh
 from trimesh.exchange import export
 
+from scadview.features import FeatureState
 from scadview.load_status import LoadStatus
 from scadview.logging_main import log_queue
 from scadview.mesh_loader_process import (
@@ -34,9 +35,12 @@ def export_formats() -> list[str]:
 class Controller:
     def __init__(self):
         self.on_module_path_set = Observable()
+        self.on_features_change = Observable()
         self.module_path = ""
         self._last_export_path = ""
         self._closed = False
+        self._current_mesh: list[Trimesh] | Trimesh | None = None
+        self._feature_states: list[FeatureState] = []
         self._load_queue = MpLoadQueue(maxsize=1, type_=LoadResult)
         self._command_queue = MpCommandQueue(maxsize=0, type_=Command)
         self._loader_process = MeshLoaderProcess(
@@ -56,6 +60,17 @@ class Controller:
     @current_mesh.setter
     def current_mesh(self, value: list[Trimesh] | Trimesh | None):
         self._current_mesh = value
+
+    @property
+    def feature_states(self) -> list[FeatureState]:
+        return self._feature_states
+
+    @feature_states.setter
+    def feature_states(self, value: list[FeatureState]):
+        if self._feature_states == value:
+            return
+        self._feature_states = value
+        self.on_features_change.notify(value)
 
     @property
     def module_path(self) -> str:
@@ -85,8 +100,9 @@ class Controller:
                 ""  # Reset last export path if loading a new module
             )
             self.module_path = module_path
+            self.feature_states = []
         logger.info(f"Starting load of {module_path}")
-        self._command_queue.put(LoadMeshCommand(module_path))
+        self._command_queue.put(LoadMeshCommand(module_path, self._feature_state_map()))
 
     def reload_mesh(self):
         if self.module_path == "":
@@ -101,11 +117,22 @@ class Controller:
                 self.current_mesh = load_result.mesh
             else:
                 logger.debug("check_load_queue got mesh == None")
+            self.feature_states = load_result.features or []
             self.load_status = load_result.status
         except queue.Empty:
             logger.debug("check_load_queue empty")
             load_result = LoadResult(0, 0, None, None, False)
         return load_result
+
+    def set_feature_enabled(self, name: str, enabled: bool):
+        if self.module_path == "":
+            raise ValueError("No module loaded")
+        feature_states = self._feature_state_map()
+        if feature_states.get(name, True) == enabled:
+            return
+        feature_states[name] = enabled
+        self.feature_states = self._feature_states_with_override(name, enabled)
+        self._queue_feature_reload(feature_states)
 
     def export(self, file_path: str):
         # Cache the property so type narrowing is stable for the selected mesh.
@@ -148,6 +175,31 @@ class Controller:
 
         self._command_queue.close()
         self._load_queue.close()
+
+    def _feature_state_map(self) -> dict[str, bool]:
+        return {feature.name: feature.enabled for feature in self.feature_states}
+
+    def _feature_states_with_override(
+        self,
+        name: str,
+        enabled: bool,
+    ) -> list[FeatureState]:
+        updated_feature_states: list[FeatureState] = []
+        found = False
+        for feature in self.feature_states:
+            if feature.name == name:
+                updated_feature_states.append(FeatureState(name, enabled))
+                found = True
+            else:
+                updated_feature_states.append(feature)
+        if not found:
+            updated_feature_states.append(FeatureState(name, enabled))
+        return updated_feature_states
+
+    def _queue_feature_reload(self, feature_states: dict[str, bool]):
+        self.current_mesh = None
+        self.load_status = LoadStatus.START
+        self._command_queue.put(LoadMeshCommand(self.module_path, feature_states))
 
     def __del__(self):
         try:

--- a/src/scadview/features.py
+++ b/src/scadview/features.py
@@ -205,20 +205,28 @@ class FeatureMesh:
 class _FeatureContext:
     def __init__(self) -> None:
         self._states: dict[str, bool] = {}
+        self._defaults: dict[str, bool] = {}
         self._order: list[str] = []
 
     def set_enabled_states(self, states: dict[str, bool] | None) -> None:
         self._states = {} if states is None else dict(states)
+        self._defaults = {}
         self._order = []
+
+    def set_default(self, name: str, enabled: bool) -> None:
+        if name in self._defaults and self._defaults[name] != enabled:
+            raise ValueError(f"Conflicting default for feature {name!r}")
+        self._defaults[name] = enabled
 
     def register(self, name: str) -> bool:
         if name not in self._order:
             self._order.append(name)
-        return self._states.get(name, True)
+        return self._states.get(name, self._defaults.get(name, True))
 
     def states(self) -> list[FeatureState]:
         return [
-            FeatureState(name, self._states.get(name, True)) for name in self._order
+            FeatureState(name, self._states.get(name, self._defaults.get(name, True)))
+            for name in self._order
         ]
 
 
@@ -236,6 +244,10 @@ def set_enabled_feature_states(states: dict[str, bool] | None) -> None:
 
 def get_feature_states() -> list[FeatureState]:
     return _FEATURE_CONTEXT.states()
+
+
+def feature_default(name: str, enabled: bool = True) -> None:
+    _FEATURE_CONTEXT.set_default(name, enabled)
 
 
 @overload

--- a/src/scadview/features.py
+++ b/src/scadview/features.py
@@ -3,15 +3,41 @@ from __future__ import annotations
 import inspect
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, ParamSpec, TypeAlias, TypeVar, cast, overload
+from typing import (
+    Any,
+    Callable,
+    ParamSpec,
+    Protocol,
+    TypeAlias,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from manifold3d import Manifold
 from trimesh import Trimesh
 
 FeatureNativeMesh: TypeAlias = Trimesh | Manifold
-FeatureNativeMeshOrNone: TypeAlias = FeatureNativeMesh | None
 P = ParamSpec("P")
 TNativeMesh = TypeVar("TNativeMesh", Trimesh, Manifold)
+
+
+class BooleanOperand(Protocol):
+    def as_operand(self) -> BooleanOperand: ...
+
+    def is_empty(self) -> bool: ...
+
+    def union(self, other: Any) -> Any: ...
+
+    def difference(self, other: Any) -> Any: ...
+
+    def intersection(self, other: Any) -> Any: ...
+
+    def __add__(self, other: Any) -> Any: ...
+
+    def __sub__(self, other: Any) -> Any: ...
+
+    def __xor__(self, other: Any) -> Any: ...
 
 
 @dataclass(frozen=True)
@@ -21,11 +47,17 @@ class FeatureState:
 
 
 class NullFeatureMesh:
-    def resolve(self) -> None:
-        return None
+    def as_operand(self) -> NullFeatureMesh:
+        return self
+
+    def is_empty(self) -> bool:
+        return True
 
     def union(self, other: Any) -> Any:
-        return _identity_for_disabled_feature(other)
+        operand = _to_boolean_operand(other)
+        if isinstance(operand, NullFeatureMesh):
+            return self
+        return operand.native()
 
     def difference(self, _other: Any) -> NullFeatureMesh:
         return self
@@ -34,7 +66,7 @@ class NullFeatureMesh:
         return self
 
     def __add__(self, other: Any) -> Any:
-        return _identity_for_disabled_feature(other)
+        return self.union(other)
 
     def __sub__(self, _other: Any) -> NullFeatureMesh:
         return self
@@ -43,8 +75,68 @@ class NullFeatureMesh:
         return self
 
 
+class BooleanMesh:
+    def __init__(self, mesh: FeatureNativeMesh) -> None:
+        if not _is_native_mesh(mesh):
+            raise TypeError(
+                f"boolean mesh must be Trimesh or Manifold, got {type(mesh)}"
+            )
+        self._mesh = mesh
+
+    def as_operand(self) -> BooleanMesh:
+        return self
+
+    def is_empty(self) -> bool:
+        return False
+
+    def native(self) -> FeatureNativeMesh:
+        return self._mesh
+
+    def union(self, other: Any) -> Any:
+        mesh = _require_trimesh(self._mesh, "union")
+        operand = _to_boolean_operand(other)
+        if operand.is_empty():
+            return mesh
+        return mesh.union(_require_trimesh(_native(operand), "union"))
+
+    def difference(self, other: Any) -> Any:
+        mesh = _require_trimesh(self._mesh, "difference")
+        operand = _to_boolean_operand(other)
+        if operand.is_empty():
+            return mesh
+        return mesh.difference(_require_trimesh(_native(operand), "difference"))
+
+    def intersection(self, other: Any) -> Any:
+        mesh = _require_trimesh(self._mesh, "intersection")
+        operand = _to_boolean_operand(other)
+        if operand.is_empty():
+            return NullFeatureMesh()
+        return mesh.intersection(_require_trimesh(_native(operand), "intersection"))
+
+    def __add__(self, other: Any) -> Any:
+        mesh = _require_manifold(self._mesh, "+")
+        operand = _to_boolean_operand(other)
+        if operand.is_empty():
+            return mesh
+        return mesh + _require_manifold(_native(operand), "+")
+
+    def __sub__(self, other: Any) -> Any:
+        mesh = _require_manifold(self._mesh, "-")
+        operand = _to_boolean_operand(other)
+        if operand.is_empty():
+            return mesh
+        return mesh - _require_manifold(_native(operand), "-")
+
+    def __xor__(self, other: Any) -> Any:
+        mesh = _require_manifold(self._mesh, "^")
+        operand = _to_boolean_operand(other)
+        if operand.is_empty():
+            return NullFeatureMesh()
+        return mesh ^ _require_manifold(_native(operand), "^")
+
+
 class FeatureMesh:
-    def __init__(self, name: str, mesh: FeatureNativeMesh, enabled: bool):
+    def __init__(self, name: str, mesh: FeatureNativeMesh, enabled: bool) -> None:
         self._name = name
         self._mesh = mesh
         self._enabled = enabled
@@ -57,40 +149,43 @@ class FeatureMesh:
     def enabled(self) -> bool:
         return self._enabled
 
-    def resolve(self) -> FeatureNativeMeshOrNone:
+    def as_operand(self) -> BooleanMesh | NullFeatureMesh:
         if self._enabled:
-            return self._mesh
-        return None
+            return BooleanMesh(self._mesh)
+        return NullFeatureMesh()
+
+    def is_empty(self) -> bool:
+        return self.as_operand().is_empty()
 
     def union(self, other: Any) -> Any:
         if not hasattr(self._mesh, "union"):
             raise AttributeError(
                 f"{type(self._mesh).__name__!s} has no attribute 'union'"
             )
-        return self._call_native_operation("union", other)
+        return self.as_operand().union(other)
 
     def difference(self, other: Any) -> Any:
         if not hasattr(self._mesh, "difference"):
             raise AttributeError(
                 f"{type(self._mesh).__name__!s} has no attribute 'difference'"
             )
-        return self._call_native_operation("difference", other)
+        return self.as_operand().difference(other)
 
     def intersection(self, other: Any) -> Any:
         if not hasattr(self._mesh, "intersection"):
             raise AttributeError(
                 f"{type(self._mesh).__name__!s} has no attribute 'intersection'"
             )
-        return self._call_native_operation("intersection", other)
+        return self.as_operand().intersection(other)
 
     def __add__(self, other: Any) -> Any:
-        return self._call_native_operator("__add__", other)
+        return self.as_operand() + other
 
     def __sub__(self, other: Any) -> Any:
-        return self._call_native_operator("__sub__", other)
+        return self.as_operand() - other
 
     def __xor__(self, other: Any) -> Any:
-        return self._call_native_operator("__xor__", other)
+        return self.as_operand() ^ other
 
     def __getattr__(self, name: str) -> Any:
         attr = getattr(self._mesh, name)
@@ -106,29 +201,13 @@ class FeatureMesh:
 
         return _wrapped
 
-    def _call_native_operation(self, name: str, other: Any) -> Any:
-        if not self._enabled:
-            return _identity_for_disabled_feature(other)
-        resolved_other = _resolve_operand(other)
-        if resolved_other is None:
-            return self._mesh
-        return getattr(self._mesh, name)(resolved_other)
-
-    def _call_native_operator(self, name: str, other: Any) -> Any:
-        if not self._enabled:
-            return _identity_for_disabled_feature(other)
-        resolved_other = _resolve_operand(other)
-        if resolved_other is None:
-            return self._mesh
-        return getattr(self._mesh, name)(resolved_other)
-
 
 class _FeatureContext:
-    def __init__(self):
+    def __init__(self) -> None:
         self._states: dict[str, bool] = {}
         self._order: list[str] = []
 
-    def set_enabled_states(self, states: dict[str, bool] | None):
+    def set_enabled_states(self, states: dict[str, bool] | None) -> None:
         self._states = {} if states is None else dict(states)
         self._order = []
 
@@ -209,6 +288,8 @@ def feature(
 
 
 def _feature_mesh(name: str, mesh: FeatureNativeMesh) -> FeatureMesh:
+    if not _is_native_mesh(mesh):
+        raise TypeError(f"feature mesh must be Trimesh or Manifold, got {type(mesh)}")
     enabled = _FEATURE_CONTEXT.register(name)
     return FeatureMesh(name, mesh, enabled)
 
@@ -232,19 +313,36 @@ def _feature_decorator(
     return _decorate
 
 
-def _identity_for_disabled_feature(other: Any) -> Any:
-    resolved_other = _resolve_operand(other)
-    if resolved_other is not None:
-        return resolved_other
-    return NullFeatureMesh()
-
-
-def _resolve_operand(value: Any) -> FeatureNativeMeshOrNone | Any:
+def _to_boolean_operand(value: Any) -> BooleanMesh | NullFeatureMesh:
     if isinstance(value, FeatureMesh):
-        return value.resolve()
+        return value.as_operand()
+    if isinstance(value, BooleanMesh):
+        return value
     if isinstance(value, NullFeatureMesh):
-        return None
-    return value
+        return value
+    return BooleanMesh(value)
+
+
+def _native(operand: BooleanMesh | NullFeatureMesh) -> FeatureNativeMesh:
+    if isinstance(operand, BooleanMesh):
+        return operand.native()
+    raise TypeError("Expected non-empty boolean operand")
+
+
+def _has_feature_operand(value: Any) -> bool:
+    return isinstance(value, FeatureMesh | NullFeatureMesh)
+
+
+def _require_trimesh(mesh: FeatureNativeMesh, operation: str) -> Trimesh:
+    if isinstance(mesh, Trimesh):
+        return mesh
+    raise TypeError(f"{operation} requires Trimesh operands")
+
+
+def _require_manifold(mesh: FeatureNativeMesh, operation: str) -> Manifold:
+    if isinstance(mesh, Manifold):
+        return mesh
+    raise TypeError(f"{operation} requires Manifold operands")
 
 
 def _is_native_mesh(value: Any) -> bool:
@@ -265,11 +363,11 @@ def _patch_native_boolean_members() -> None:
                 self: Any,
                 other: Any,
                 _original: Callable[..., Any] = original,
+                _member_name: str = member_name,
             ) -> Any:
-                resolved_other = _resolve_operand(other)
-                if resolved_other is None:
-                    return self
-                return _original(self, resolved_other)
+                if _has_feature_operand(other):
+                    return getattr(BooleanMesh(self), _member_name)(other)
+                return _original(self, other)
 
             setattr(cls, member_name, _patched)
             _PATCHED_MEMBERS.add(key)

--- a/src/scadview/features.py
+++ b/src/scadview/features.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     Callable,
     ParamSpec,
-    Protocol,
     TypeAlias,
     TypeVar,
     cast,
@@ -20,24 +19,6 @@ from trimesh import Trimesh
 FeatureNativeMesh: TypeAlias = Trimesh | Manifold
 P = ParamSpec("P")
 TNativeMesh = TypeVar("TNativeMesh", Trimesh, Manifold)
-
-
-class BooleanOperand(Protocol):
-    def as_operand(self) -> BooleanOperand: ...
-
-    def is_empty(self) -> bool: ...
-
-    def union(self, other: Any) -> Any: ...
-
-    def difference(self, other: Any) -> Any: ...
-
-    def intersection(self, other: Any) -> Any: ...
-
-    def __add__(self, other: Any) -> Any: ...
-
-    def __sub__(self, other: Any) -> Any: ...
-
-    def __xor__(self, other: Any) -> Any: ...
 
 
 @dataclass(frozen=True)

--- a/src/scadview/features.py
+++ b/src/scadview/features.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import wraps
+import inspect
+from typing import Any, Callable, ParamSpec, TypeAlias, TypeVar, cast, overload
+
+from manifold3d import Manifold
+from trimesh import Trimesh
+
+FeatureNativeMesh: TypeAlias = Trimesh | Manifold
+FeatureNativeMeshOrNone: TypeAlias = FeatureNativeMesh | None
+P = ParamSpec("P")
+TNativeMesh = TypeVar("TNativeMesh", Trimesh, Manifold)
+
+
+@dataclass(frozen=True)
+class FeatureState:
+    name: str
+    enabled: bool = True
+
+
+class FeatureMesh:
+    def __init__(self, name: str, mesh: FeatureNativeMesh, enabled: bool):
+        self._name = name
+        self._mesh = mesh
+        self._enabled = enabled
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def resolve(self) -> FeatureNativeMeshOrNone:
+        if self._enabled:
+            return self._mesh
+        return None
+
+    def union(self, other: Any) -> Any:
+        if not hasattr(self._mesh, "union"):
+            raise AttributeError(
+                f"{type(self._mesh).__name__!s} has no attribute 'union'"
+            )
+        return self._call_native_operation("union", other)
+
+    def difference(self, other: Any) -> Any:
+        if not hasattr(self._mesh, "difference"):
+            raise AttributeError(
+                f"{type(self._mesh).__name__!s} has no attribute 'difference'"
+            )
+        return self._call_native_operation("difference", other)
+
+    def intersection(self, other: Any) -> Any:
+        if not hasattr(self._mesh, "intersection"):
+            raise AttributeError(
+                f"{type(self._mesh).__name__!s} has no attribute 'intersection'"
+            )
+        return self._call_native_operation("intersection", other)
+
+    def __add__(self, other: Any) -> Any:
+        return self._call_native_operator("__add__", other)
+
+    def __sub__(self, other: Any) -> Any:
+        return self._call_native_operator("__sub__", other)
+
+    def __xor__(self, other: Any) -> Any:
+        return self._call_native_operator("__xor__", other)
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._mesh, name)
+        if not callable(attr):
+            return attr
+
+        @wraps(attr)
+        def _wrapped(*args: Any, **kwargs: Any) -> Any:
+            result = attr(*args, **kwargs)
+            if _is_native_mesh(result):
+                return FeatureMesh(self._name, result, self._enabled)
+            return result
+
+        return _wrapped
+
+    def _call_native_operation(self, name: str, other: Any) -> Any:
+        if not self._enabled:
+            return _identity_for_disabled_feature(other)
+        resolved_other = _resolve_operand(other)
+        if resolved_other is None:
+            return self._mesh
+        return getattr(self._mesh, name)(resolved_other)
+
+    def _call_native_operator(self, name: str, other: Any) -> Any:
+        if not self._enabled:
+            return _identity_for_disabled_feature(other)
+        resolved_other = _resolve_operand(other)
+        if resolved_other is None:
+            return self._mesh
+        return getattr(self._mesh, name)(resolved_other)
+
+
+class _FeatureContext:
+    def __init__(self):
+        self._states: dict[str, bool] = {}
+        self._order: list[str] = []
+
+    def set_enabled_states(self, states: dict[str, bool] | None):
+        self._states = {} if states is None else dict(states)
+        self._order = []
+
+    def register(self, name: str) -> bool:
+        if name not in self._order:
+            self._order.append(name)
+        return self._states.get(name, True)
+
+    def states(self) -> list[FeatureState]:
+        return [
+            FeatureState(name, self._states.get(name, True)) for name in self._order
+        ]
+
+
+_FEATURE_CONTEXT = _FeatureContext()
+_PATCHED_MEMBERS: set[tuple[type[Any], str]] = set()
+_NATIVE_BOOLEAN_MEMBERS: dict[type[Any], tuple[str, ...]] = {
+    Trimesh: ("union", "difference", "intersection"),
+    Manifold: ("__add__", "__sub__", "__xor__"),
+}
+
+
+def set_enabled_feature_states(states: dict[str, bool] | None) -> None:
+    _FEATURE_CONTEXT.set_enabled_states(states)
+
+
+def get_feature_states() -> list[FeatureState]:
+    return _FEATURE_CONTEXT.states()
+
+
+@overload
+def feature(name: str, mesh: TNativeMesh) -> FeatureMesh: ...
+
+
+@overload
+def feature(func: Callable[P, TNativeMesh]) -> Callable[P, FeatureMesh]: ...
+
+
+@overload
+def feature(
+    name: str,
+) -> Callable[[Callable[P, TNativeMesh]], Callable[P, FeatureMesh]]: ...
+
+
+def feature(
+    name_or_func: str | Callable[P, TNativeMesh],
+    mesh: TNativeMesh | None = None,
+) -> (
+    FeatureMesh
+    | Callable[P, FeatureMesh]
+    | Callable[[Callable[P, TNativeMesh]], Callable[P, FeatureMesh]]
+):
+    if mesh is not None:
+        if not isinstance(name_or_func, str):
+            raise TypeError("Expected feature name to be a string")
+        return _feature_mesh(name_or_func, mesh)
+
+    if isinstance(name_or_func, str):
+        return cast(
+            Callable[[Callable[P, TNativeMesh]], Callable[P, FeatureMesh]],
+            _feature_decorator(name_or_func),
+        )
+
+    if callable(name_or_func):
+        if inspect.isclass(name_or_func):
+            raise TypeError(
+                "@feature only supports mesh-returning functions or methods, "
+                "not classes"
+            )
+        func = cast(Callable[P, TNativeMesh], name_or_func)
+        feature_name = getattr(func, "__name__", "feature")
+        return cast(
+            Callable[P, FeatureMesh],
+            _feature_decorator(feature_name)(func),
+        )
+
+    raise TypeError("Expected feature to be called with a name, mesh, or function")
+
+
+def _feature_mesh(name: str, mesh: FeatureNativeMesh) -> FeatureMesh:
+    enabled = _FEATURE_CONTEXT.register(name)
+    return FeatureMesh(name, mesh, enabled)
+
+
+def _feature_decorator(
+    name: str,
+) -> Callable[[Callable[P, TNativeMesh]], Callable[P, FeatureMesh]]:
+    def _decorate(func: Callable[P, TNativeMesh]) -> Callable[P, FeatureMesh]:
+        @wraps(func)
+        def _wrapped(*args: P.args, **kwargs: P.kwargs) -> FeatureMesh:
+            mesh = func(*args, **kwargs)
+            if not _is_native_mesh(mesh):
+                raise TypeError(
+                    "@feature-decorated functions must return Trimesh or Manifold, "
+                    f"got {type(mesh)}"
+                )
+            return _feature_mesh(name, mesh)
+
+        return _wrapped
+
+    return _decorate
+
+
+def _identity_for_disabled_feature(other: Any) -> Any:
+    resolved_other = _resolve_operand(other)
+    if resolved_other is not None:
+        return resolved_other
+    return None
+
+
+def _resolve_operand(value: Any) -> FeatureNativeMeshOrNone | Any:
+    if isinstance(value, FeatureMesh):
+        return value.resolve()
+    return value
+
+
+def _is_native_mesh(value: Any) -> bool:
+    return isinstance(value, Trimesh | Manifold)
+
+
+def _patch_native_boolean_members() -> None:
+    for cls, member_names in _NATIVE_BOOLEAN_MEMBERS.items():
+        for member_name in member_names:
+            key = (cls, member_name)
+            if key in _PATCHED_MEMBERS:
+                continue
+            if not hasattr(cls, member_name):
+                continue
+            original = getattr(cls, member_name)
+
+            def _patched(
+                self: Any,
+                other: Any,
+                _original: Callable[..., Any] = original,
+            ) -> Any:
+                resolved_other = _resolve_operand(other)
+                if resolved_other is None:
+                    return self
+                return _original(self, resolved_other)
+
+            setattr(cls, member_name, _patched)
+            _PATCHED_MEMBERS.add(key)
+
+
+_patch_native_boolean_members()

--- a/src/scadview/features.py
+++ b/src/scadview/features.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from functools import wraps
-import inspect
 from typing import Any, Callable, ParamSpec, TypeAlias, TypeVar, cast, overload
 
 from manifold3d import Manifold

--- a/src/scadview/features.py
+++ b/src/scadview/features.py
@@ -20,6 +20,29 @@ class FeatureState:
     enabled: bool = True
 
 
+class NullFeatureMesh:
+    def resolve(self) -> None:
+        return None
+
+    def union(self, other: Any) -> Any:
+        return _identity_for_disabled_feature(other)
+
+    def difference(self, _other: Any) -> NullFeatureMesh:
+        return self
+
+    def intersection(self, _other: Any) -> NullFeatureMesh:
+        return self
+
+    def __add__(self, other: Any) -> Any:
+        return _identity_for_disabled_feature(other)
+
+    def __sub__(self, _other: Any) -> NullFeatureMesh:
+        return self
+
+    def __xor__(self, _other: Any) -> NullFeatureMesh:
+        return self
+
+
 class FeatureMesh:
     def __init__(self, name: str, mesh: FeatureNativeMesh, enabled: bool):
         self._name = name
@@ -213,12 +236,14 @@ def _identity_for_disabled_feature(other: Any) -> Any:
     resolved_other = _resolve_operand(other)
     if resolved_other is not None:
         return resolved_other
-    return None
+    return NullFeatureMesh()
 
 
 def _resolve_operand(value: Any) -> FeatureNativeMeshOrNone | Any:
     if isinstance(value, FeatureMesh):
         return value.resolve()
+    if isinstance(value, NullFeatureMesh):
+        return None
     return value
 
 

--- a/src/scadview/mesh_loader_process.py
+++ b/src/scadview/mesh_loader_process.py
@@ -20,6 +20,7 @@ from scadview.api.utils import manifold_to_trimesh
 from scadview.features import (
     FeatureMesh,
     FeatureState,
+    NullFeatureMesh,
     get_feature_states,
     set_enabled_feature_states,
 )
@@ -95,7 +96,7 @@ class ShutDownCommand(Command):
 
 
 MeshType = Trimesh | list[Trimesh]
-CreateMeshItemType = Trimesh | Manifold | FeatureMesh
+CreateMeshItemType = Trimesh | Manifold | FeatureMesh | NullFeatureMesh
 CreateMeshResultType = CreateMeshItemType | list[CreateMeshItemType]
 
 
@@ -202,6 +203,8 @@ class LoadWorker(Thread):
     def _ensure_trimesh(self, mesh: CreateMeshResultType | None) -> MeshType | None:
         if mesh is None:
             return None
+        if isinstance(mesh, NullFeatureMesh):
+            return None
         if isinstance(mesh, FeatureMesh):
             return self._ensure_trimesh(mesh.resolve())
         if isinstance(mesh, Trimesh):
@@ -277,6 +280,8 @@ class LoadWorker(Thread):
         if isinstance(mesh, FeatureMesh):
             self._check_feature_mesh(mesh)
             return
+        if isinstance(mesh, NullFeatureMesh):
+            return
         if isinstance(mesh, Trimesh):
             self._check_trimesh_vertices(mesh)
             return
@@ -287,6 +292,8 @@ class LoadWorker(Thread):
             for i, m in enumerate(mesh):
                 if isinstance(m, FeatureMesh):
                     self._check_feature_mesh(m, i)
+                    continue
+                if isinstance(m, NullFeatureMesh):
                     continue
                 if isinstance(m, Trimesh):
                     self._check_trimesh_vertices(m)

--- a/src/scadview/mesh_loader_process.py
+++ b/src/scadview/mesh_loader_process.py
@@ -18,6 +18,7 @@ from trimesh import Trimesh
 from scadview.api.colors import set_mesh_color
 from scadview.api.utils import manifold_to_trimesh
 from scadview.features import (
+    BooleanMesh,
     FeatureMesh,
     FeatureState,
     NullFeatureMesh,
@@ -96,7 +97,7 @@ class ShutDownCommand(Command):
 
 
 MeshType = Trimesh | list[Trimesh]
-CreateMeshItemType = Trimesh | Manifold | FeatureMesh | NullFeatureMesh
+CreateMeshItemType = Trimesh | Manifold | FeatureMesh | BooleanMesh | NullFeatureMesh
 CreateMeshResultType = CreateMeshItemType | list[CreateMeshItemType]
 
 
@@ -206,7 +207,9 @@ class LoadWorker(Thread):
         if isinstance(mesh, NullFeatureMesh):
             return None
         if isinstance(mesh, FeatureMesh):
-            return self._ensure_trimesh(mesh.resolve())
+            return self._ensure_trimesh(mesh.as_operand())
+        if isinstance(mesh, BooleanMesh):
+            return self._ensure_trimesh(mesh.native())
         if isinstance(mesh, Trimesh):
             return mesh
         if isinstance(mesh, Manifold):
@@ -215,10 +218,11 @@ class LoadWorker(Thread):
             result: list[Trimesh] = []
             for m in mesh:
                 if isinstance(m, FeatureMesh):
-                    resolved_feature = m.resolve()
-                    if resolved_feature is None:
+                    operand = m.as_operand()
+                    if operand.is_empty():
                         continue
-                    m = resolved_feature
+                    if isinstance(operand, BooleanMesh):
+                        m = operand.native()
                 if isinstance(m, Trimesh):
                     result.append(m)
                 elif isinstance(m, Manifold):
@@ -317,9 +321,12 @@ class LoadWorker(Thread):
         feature_mesh: FeatureMesh,
         list_index: int | None = None,
     ):
-        resolved_mesh = feature_mesh.resolve()
-        if resolved_mesh is None:
+        operand = feature_mesh.as_operand()
+        if operand.is_empty():
             return
+        if not isinstance(operand, BooleanMesh):
+            raise TypeError(f"Expected non-empty feature mesh, got {type(operand)}")
+        resolved_mesh = operand.native()
         if isinstance(resolved_mesh, Trimesh):
             self._check_trimesh_vertices(resolved_mesh)
             return

--- a/src/scadview/mesh_loader_process.py
+++ b/src/scadview/mesh_loader_process.py
@@ -17,6 +17,12 @@ from trimesh import Trimesh
 
 from scadview.api.colors import set_mesh_color
 from scadview.api.utils import manifold_to_trimesh
+from scadview.features import (
+    FeatureMesh,
+    FeatureState,
+    get_feature_states,
+    set_enabled_feature_states,
+)
 from scadview.load_status import LoadStatus
 from scadview.logging_worker import configure_worker_logging
 from scadview.module_loader import ModuleLoader
@@ -71,8 +77,13 @@ class Command:
 
 
 class LoadMeshCommand(Command):
-    def __init__(self, module_path: str):
+    def __init__(
+        self,
+        module_path: str,
+        feature_states: dict[str, bool] | None = None,
+    ):
         self.module_path = module_path
+        self.feature_states = feature_states or {}
 
 
 class CancelLoadCommand(Command):
@@ -84,7 +95,8 @@ class ShutDownCommand(Command):
 
 
 MeshType = Trimesh | list[Trimesh]
-CreateMeshResultType = Trimesh | Manifold | list[Trimesh | Manifold]
+CreateMeshItemType = Trimesh | Manifold | FeatureMesh
+CreateMeshResultType = CreateMeshItemType | list[CreateMeshItemType]
 
 
 @dataclass
@@ -94,6 +106,7 @@ class LoadResult:
     mesh: MeshType | None
     error: Exception | None
     complete: bool = False
+    features: list[FeatureState] | None = None
 
     @property
     def debug(self) -> bool:
@@ -130,11 +143,18 @@ class LoadWorker(Thread):
     PUT_QUEUE_TIMEOUT = 0.1
     load_number = 0
 
-    def __init__(self, module_path: str, load_queue: MpLoadQueue):
+    def __init__(
+        self,
+        module_path: str,
+        load_queue: MpLoadQueue,
+        feature_states: dict[str, bool] | None = None,
+    ):
         super().__init__()
         self.module_path = module_path
         self.load_queue = load_queue
         self.cancelled = False
+        self.feature_states = feature_states or {}
+        self._loaded_feature_states: list[FeatureState] = []
 
     def run(self):
         LoadWorker.load_number += 1
@@ -161,7 +181,7 @@ class LoadWorker(Thread):
     def _update_mesh(
         self,
         sequence_number: int,
-        mesh: MeshType | None,
+        mesh: CreateMeshResultType | None,
         final: bool = False,
         error: Exception | None = None,
     ):
@@ -175,12 +195,15 @@ class LoadWorker(Thread):
                 tmesh,
                 error=error,
                 complete=final,
+                features=self._current_feature_states(),
             )
         )
 
-    def _ensure_trimesh(self, mesh: Any) -> MeshType | None:
+    def _ensure_trimesh(self, mesh: CreateMeshResultType | None) -> MeshType | None:
         if mesh is None:
             return None
+        if isinstance(mesh, FeatureMesh):
+            return self._ensure_trimesh(mesh.resolve())
         if isinstance(mesh, Trimesh):
             return mesh
         if isinstance(mesh, Manifold):
@@ -188,6 +211,11 @@ class LoadWorker(Thread):
         if isinstance(mesh, list):
             result: list[Trimesh] = []
             for m in mesh:
+                if isinstance(m, FeatureMesh):
+                    resolved_feature = m.resolve()
+                    if resolved_feature is None:
+                        continue
+                    m = resolved_feature
                 if isinstance(m, Trimesh):
                     result.append(m)
                 elif isinstance(m, Manifold):
@@ -196,9 +224,12 @@ class LoadWorker(Thread):
                     raise TypeError(
                         f"Expected mesh item to be of type Trimesh or Manifold, got {type(m)}"
                     )
+            if not result:
+                return None
             return result
         raise TypeError(
-            f"Expected mesh to be of type Trimesh, list[Trimesh], Manifold, or list[Manifold], got {type(mesh)}"
+            "Expected mesh to be of type Trimesh, FeatureMesh, list[Trimesh], "
+            f"Manifold, or list[Manifold], got {type(mesh)}"
         )
 
     def _color_if_debug(self, tmesh: MeshType | None):
@@ -222,17 +253,30 @@ class LoadWorker(Thread):
                 except queue.Empty:
                     pass
 
-    def run_mesh_module(self) -> Generator[MeshType, None, None]:
+    def run_mesh_module(self) -> Generator[CreateMeshResultType, None, None]:
         module_loader = ModuleLoader(CREATE_MESH_FUNCTION_NAME)
+        set_enabled_feature_states(self.feature_states)
         t0 = time()
-        for i, mesh in enumerate(module_loader.run_function(self.module_path)):
-            logger.info(f"Loading mesh #{i + 1}")
-            self._check_mesh_type(mesh)
-            yield mesh
-        t1 = time()
-        logger.info(f"Load {self.module_path} took {(t1 - t0) * 1000:.1f}ms")
+        try:
+            for i, mesh in enumerate(module_loader.run_function(self.module_path)):
+                logger.info(f"Loading mesh #{i + 1}")
+                self._check_mesh_type(mesh)
+                yield mesh
+        finally:
+            t1 = time()
+            logger.info(f"Load {self.module_path} took {(t1 - t0) * 1000:.1f}ms")
+            set_enabled_feature_states(None)
+
+    def _current_feature_states(self) -> list[FeatureState]:
+        feature_states = get_feature_states()
+        if feature_states:
+            self._loaded_feature_states = feature_states
+        return self._loaded_feature_states
 
     def _check_mesh_type(self, mesh: Any):
+        if isinstance(mesh, FeatureMesh):
+            self._check_feature_mesh(mesh)
+            return
         if isinstance(mesh, Trimesh):
             self._check_trimesh_vertices(mesh)
             return
@@ -241,6 +285,9 @@ class LoadWorker(Thread):
             return
         if isinstance(mesh, list):
             for i, m in enumerate(mesh):
+                if isinstance(m, FeatureMesh):
+                    self._check_feature_mesh(m, i)
+                    continue
                 if isinstance(m, Trimesh):
                     self._check_trimesh_vertices(m)
                     continue
@@ -249,11 +296,37 @@ class LoadWorker(Thread):
                     continue
                 if not isinstance(m, Trimesh) and not isinstance(m, Manifold):
                     raise TypeError(
-                        f"Expected mesh[{i}] to be of type Trimesh or Manifold, got {type(m)}"
+                        f"Expected mesh[{i}] to be of type Trimesh, FeatureMesh "
+                        f"or Manifold, got {type(m)}"
                     )
             return
         raise TypeError(
-            f"Expected mesh to be of type Trimesh, list[Trimesh], Manifold, or list[Manifold], got {type(mesh)}"
+            "Expected mesh to be of type Trimesh, FeatureMesh, list[Trimesh], "
+            f"Manifold, or list[Manifold], got {type(mesh)}"
+        )
+
+    def _check_feature_mesh(
+        self,
+        feature_mesh: FeatureMesh,
+        list_index: int | None = None,
+    ):
+        resolved_mesh = feature_mesh.resolve()
+        if resolved_mesh is None:
+            return
+        if isinstance(resolved_mesh, Trimesh):
+            self._check_trimesh_vertices(resolved_mesh)
+            return
+        if isinstance(resolved_mesh, Manifold):
+            self._check_manifold(resolved_mesh, list_index)
+            return
+        if list_index is None:
+            raise TypeError(
+                "Expected feature mesh to resolve to Trimesh or Manifold, "
+                f"got {type(resolved_mesh)}"
+            )
+        raise TypeError(
+            f"Expected feature mesh[{list_index}] to resolve to Trimesh or "
+            f"Manifold, got {type(resolved_mesh)}"
         )
 
     def _check_trimesh_vertices(self, mesh: Trimesh):
@@ -317,7 +390,11 @@ class MeshLoaderProcess(Process):
             if isinstance(command, LoadMeshCommand):
                 self.cancel()
                 logger.info(f"Loading mesh from {command.module_path}")
-                self._worker = LoadWorker(command.module_path, self._load_queue)
+                self._worker = LoadWorker(
+                    command.module_path,
+                    self._load_queue,
+                    feature_states=command.feature_states,
+                )
                 self._worker.start()
             elif isinstance(command, CancelLoadCommand):
                 logger.info("Load cancelled")

--- a/src/scadview/mesh_loader_process.py
+++ b/src/scadview/mesh_loader_process.py
@@ -97,7 +97,7 @@ class ShutDownCommand(Command):
 
 
 MeshType = Trimesh | list[Trimesh]
-CreateMeshItemType = Trimesh | Manifold | FeatureMesh | BooleanMesh | NullFeatureMesh
+CreateMeshItemType = Trimesh | Manifold | FeatureMesh | NullFeatureMesh
 CreateMeshResultType = CreateMeshItemType | list[CreateMeshItemType]
 
 
@@ -207,9 +207,12 @@ class LoadWorker(Thread):
         if isinstance(mesh, NullFeatureMesh):
             return None
         if isinstance(mesh, FeatureMesh):
-            return self._ensure_trimesh(mesh.as_operand())
-        if isinstance(mesh, BooleanMesh):
-            return self._ensure_trimesh(mesh.native())
+            operand = mesh.as_operand()
+            if operand.is_empty():
+                return None
+            if not isinstance(operand, BooleanMesh):
+                raise TypeError(f"Expected non-empty feature mesh, got {type(operand)}")
+            return self._ensure_trimesh(operand.native())
         if isinstance(mesh, Trimesh):
             return mesh
         if isinstance(mesh, Manifold):

--- a/src/scadview/render/renderer.py
+++ b/src/scadview/render/renderer.py
@@ -303,7 +303,10 @@ class Renderer:
         if isinstance(mesh, list):
             # Trimesh stubs are list-like, so make this branch's contract explicit.
             meshes = cast(list[Trimesh], mesh)
-            self.scale = max([m.scale for m in meshes])
+            if meshes:
+                self.scale = max([m.scale for m in meshes])
+            else:
+                self.scale = 1.0
         else:
             self.scale = mesh.scale
         self._main_renderee.subscribe_to_updates(self.on_program_value_change)

--- a/src/scadview/ui/wx/main_frame.py
+++ b/src/scadview/ui/wx/main_frame.py
@@ -54,8 +54,6 @@ class MainFrame(wx.Frame):
         self._add_feature_controls()
         self._add_view_buttons()
 
-        self._panel_sizer.AddStretchSpacer()
-
         root = wx.BoxSizer(wx.HORIZONTAL)
         root.Add(
             self._gl_widget,
@@ -159,11 +157,24 @@ class MainFrame(wx.Frame):
             self._button_panel,
             "Features",
         )
+        self._feature_scroll = wx.ScrolledWindow(
+            self._feature_box.GetStaticBox(),
+            style=wx.VSCROLL,
+        )
+        self._feature_scroll.SetScrollRate(0, 10)
+        self._feature_sizer = wx.BoxSizer(wx.VERTICAL)
+        self._feature_scroll.SetSizer(self._feature_sizer)
         self._feature_checkboxes: list[wx.CheckBox] = []
+        self._feature_box.Add(
+            self._feature_scroll,
+            1,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            BORDER_SIZE,
+        )
         self._feature_box.ShowItems(False)
         self._panel_sizer.Add(
             self._feature_box,
-            0,
+            1,
             wx.ALL | wx.EXPAND,
             BORDER_SIZE,
         )
@@ -210,22 +221,24 @@ class MainFrame(wx.Frame):
         self._feature_box.ShowItems(True)
         for feature in features:
             checkbox = self._create_feature_checkbox(feature)
-            self._feature_box.Add(
+            self._feature_sizer.Add(
                 checkbox,
                 0,
                 wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
                 BORDER_SIZE,
             )
             self._feature_checkboxes.append(checkbox)
+        self._feature_scroll.Layout()
+        self._feature_scroll.FitInside()
         self._button_panel.Layout()
 
     def _clear_feature_controls(self):
-        self._feature_box.Clear(delete_windows=True)
+        self._feature_sizer.Clear(delete_windows=True)
         self._feature_checkboxes = []
 
     def _create_feature_checkbox(self, feature: FeatureState) -> wx.CheckBox:
         checkbox = wx.CheckBox(
-            self._feature_box.GetStaticBox(),
+            self._feature_scroll,
             label=feature.name,
         )
         checkbox.SetValue(feature.enabled)

--- a/src/scadview/ui/wx/main_frame.py
+++ b/src/scadview/ui/wx/main_frame.py
@@ -2,8 +2,10 @@ import logging
 import os
 
 import wx
+from trimesh import Trimesh
 
 from scadview.controller import Controller, export_formats
+from scadview.features import FeatureState
 from scadview.load_status import LoadStatus
 from scadview.mesh_loader_process import LoadResult
 from scadview.render.gl_widget_adapter import GlWidgetAdapter
@@ -49,6 +51,7 @@ class MainFrame(wx.Frame):
         )
 
         self._add_file_buttons()
+        self._add_feature_controls()
         self._add_view_buttons()
 
         self._panel_sizer.AddStretchSpacer()
@@ -74,6 +77,7 @@ class MainFrame(wx.Frame):
         self._loader_last_load_number = 0
         self._loader_last_sequence_number = 0
         self._controller.on_load_status_change.subscribe(self._indicate_load_status)
+        self._controller.on_features_change.subscribe(self._update_feature_controls)
 
     def _create_file_actions(self):
         self._load_action = Action("Load .py...", self.on_load, "L")
@@ -149,11 +153,28 @@ class MainFrame(wx.Frame):
         self._export_btn = self._export_action.button(self._button_panel)
         self._panel_sizer.Add(self._export_btn, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
 
+    def _add_feature_controls(self):
+        self._feature_box = wx.StaticBoxSizer(
+            wx.VERTICAL,
+            self._button_panel,
+            "Features",
+        )
+        self._feature_checkboxes: list[wx.CheckBox] = []
+        self._feature_box.ShowItems(False)
+        self._panel_sizer.Add(
+            self._feature_box,
+            0,
+            wx.ALL | wx.EXPAND,
+            BORDER_SIZE,
+        )
+
     def _on_module_path_set(self, path: str) -> bool:
         return path != ""
 
     def _can_be_exported(self, status: LoadStatus) -> bool:
-        return status == LoadStatus.COMPLETE
+        return (
+            status == LoadStatus.COMPLETE and self._controller.current_mesh is not None
+        )
 
     def _add_view_buttons(self):
         for action in [
@@ -179,6 +200,45 @@ class MainFrame(wx.Frame):
         ]:
             chk = action.checkbox(self._button_panel)
             self._panel_sizer.Add(chk, 0, wx.ALL | wx.EXPAND, BORDER_SIZE)
+
+    def _update_feature_controls(self, features: list[FeatureState]):
+        self._clear_feature_controls()
+        if not features:
+            self._feature_box.ShowItems(False)
+            self._button_panel.Layout()
+            return
+        self._feature_box.ShowItems(True)
+        for feature in features:
+            checkbox = self._create_feature_checkbox(feature)
+            self._feature_box.Add(
+                checkbox,
+                0,
+                wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+                BORDER_SIZE,
+            )
+            self._feature_checkboxes.append(checkbox)
+        self._button_panel.Layout()
+
+    def _clear_feature_controls(self):
+        self._feature_box.Clear(delete_windows=True)
+        self._feature_checkboxes = []
+
+    def _create_feature_checkbox(self, feature: FeatureState) -> wx.CheckBox:
+        checkbox = wx.CheckBox(
+            self._feature_box.GetStaticBox(),
+            label=feature.name,
+        )
+        checkbox.SetValue(feature.enabled)
+        checkbox.Bind(
+            wx.EVT_CHECKBOX,
+            lambda evt, name=feature.name: self._on_feature_toggle(evt, name),
+        )
+        return checkbox
+
+    def _on_feature_toggle(self, event: wx.CommandEvent, name: str):
+        self._controller.set_feature_enabled(name, event.IsChecked())
+        self._loader_timer.Start(LOAD_CHECK_INTERVAL_MS)
+        self._load_progress_gauge.Pulse()
 
     def _create_file_menu(self) -> wx.Menu:
         file_menu = wx.Menu()
@@ -243,8 +303,7 @@ class MainFrame(wx.Frame):
             logger.error(load_result.error)
         if self._has_mesh_changed(load_result):
             logger.debug("on_load_time: mesh has changed")
-            if mesh is not None:  # Keep the type checker happy
-                self._gl_widget.load_mesh(mesh, "loaded mesh")
+            self._load_mesh_in_view(mesh)
             if self._is_first_in_load(load_result):
                 self._gl_widget.frame()
             self._loader_last_load_number = load_result.load_number
@@ -254,10 +313,17 @@ class MainFrame(wx.Frame):
         self._gl_widget.indicate_load_status(status)
 
     def _has_mesh_changed(self, load_result: LoadResult) -> bool:
-        return load_result.mesh is not None and (
-            self._loader_last_load_number != load_result.load_number
-            or self._loader_last_sequence_number != load_result.sequence_number
-        )
+        new_load = self._loader_last_load_number != load_result.load_number
+        new_sequence = self._loader_last_sequence_number != load_result.sequence_number
+        if load_result.mesh is not None:
+            return new_load or new_sequence
+        return load_result.complete and new_load
+
+    def _load_mesh_in_view(self, mesh: Trimesh | list[Trimesh] | None):
+        if mesh is None:
+            self._gl_widget.load_mesh([], "loaded mesh")
+            return
+        self._gl_widget.load_mesh(mesh, "loaded mesh")
 
     def _is_first_in_load(self, load_result: LoadResult) -> bool:
         return self._loader_last_load_number != load_result.load_number

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,74 @@
+import queue
+from pathlib import Path
+
+from trimesh.creation import box
+
+from scadview.controller import Controller
+from scadview.features import FeatureState
+from scadview.mesh_loader_process import LoadMeshCommand, LoadResult
+
+
+class DummyQueue:
+    def __init__(self, *_, **__):
+        self.items: list[object] = []
+
+    def put(self, item: object, block: bool = True, timeout: float | None = None):
+        self.items.append(item)
+
+    def get_nowait(self) -> object:
+        if not self.items:
+            raise queue.Empty()
+        return self.items.pop(0)
+
+    def close(self):
+        return None
+
+
+class DummyProcess:
+    def __init__(self, *_args, **_kwargs):
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+    def join(self, timeout: float = 0.0):
+        return None
+
+    def is_alive(self) -> bool:
+        return False
+
+    def terminate(self):
+        return None
+
+
+def test_controller_reloads_with_updated_feature_state(monkeypatch):
+    monkeypatch.setattr("scadview.controller.MpLoadQueue", DummyQueue)
+    monkeypatch.setattr("scadview.controller.MpCommandQueue", DummyQueue)
+    monkeypatch.setattr("scadview.controller.MeshLoaderProcess", DummyProcess)
+    controller = Controller()
+
+    try:
+        model_path = str(Path("/tmp/model.py"))
+        controller.load_mesh(model_path)
+        first_command = controller._command_queue.items.pop()
+        assert isinstance(first_command, LoadMeshCommand)
+        assert first_command.feature_states == {}
+
+        controller._load_queue.items.append(
+            LoadResult(
+                1,
+                1,
+                box(),
+                None,
+                False,
+                [FeatureState("cutout", True)],
+            )
+        )
+        controller.check_load_queue()
+        controller.set_feature_enabled("cutout", False)
+
+        second_command = controller._command_queue.items.pop()
+        assert isinstance(second_command, LoadMeshCommand)
+        assert second_command.feature_states == {"cutout": False}
+    finally:
+        controller.close()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,105 @@
+from dataclasses import dataclass
+
+import pytest
+from manifold3d import Manifold
+from trimesh.creation import box
+
+from scadview.features import (
+    FeatureState,
+    feature,
+    get_feature_states,
+    set_enabled_feature_states,
+)
+
+
+def teardown_function():
+    set_enabled_feature_states(None)
+
+
+def test_feature_registers_enabled_state_by_default():
+    optional_mesh = feature("lid", box())
+
+    assert optional_mesh.enabled
+    assert get_feature_states() == [FeatureState("lid", True)]
+
+
+def test_feature_decorator_uses_function_name_by_default():
+    @feature
+    def lid():
+        return box()
+
+    optional_mesh = lid()
+
+    assert optional_mesh.name == "lid"
+    assert optional_mesh.enabled
+    assert get_feature_states() == [FeatureState("lid", True)]
+
+
+def test_feature_decorator_accepts_explicit_name():
+    @feature("custom-lid")
+    def lid():
+        return box()
+
+    optional_mesh = lid()
+
+    assert optional_mesh.name == "custom-lid"
+    assert get_feature_states() == [FeatureState("custom-lid", True)]
+
+
+def test_feature_decorator_supports_methods():
+    @dataclass
+    class LidBuilder:
+        size: float
+
+        @feature("lid")
+        def mesh(self):
+            return box([self.size, self.size, self.size])
+
+    optional_mesh = LidBuilder(2.0).mesh()
+
+    assert optional_mesh.name == "lid"
+    assert get_feature_states() == [FeatureState("lid", True)]
+
+
+def test_feature_decorator_rejects_classes():
+    with pytest.raises(TypeError, match="not classes"):
+
+        @feature
+        @dataclass
+        class Lid:
+            size: float
+
+
+def test_feature_decorator_rejects_non_mesh_return_values():
+    @feature
+    def not_a_mesh():
+        return "nope"
+
+    with pytest.raises(TypeError, match="must return Trimesh or Manifold"):
+        not_a_mesh()
+
+
+def test_disabled_feature_is_identity_for_trimesh_boolean_methods():
+    set_enabled_feature_states({"cutout": False})
+    base = box()
+    optional = feature("cutout", box())
+
+    assert base.union(optional) is base
+    assert base.intersection(optional) is base
+    assert base.difference(optional) is base
+    assert optional.union(base) is base
+    assert optional.intersection(base) is base
+    assert optional.difference(base) is base
+
+
+def test_disabled_feature_is_identity_for_manifold_boolean_operators():
+    set_enabled_feature_states({"cutout": False})
+    base = Manifold.cube()
+    optional = feature("cutout", Manifold.cube())
+
+    assert (base + optional) is base
+    assert (base ^ optional) is base
+    assert (base - optional) is base
+    assert (optional + base) is base
+    assert (optional ^ base) is base
+    assert (optional - base) is base

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -103,3 +103,13 @@ def test_disabled_feature_is_identity_for_manifold_boolean_operators():
     assert (optional + base) is base
     assert (optional ^ base) is base
     assert (optional - base) is base
+
+
+def test_disabled_feature_chain_returns_null_feature_mesh():
+    set_enabled_feature_states({"platform": False, "guide": False})
+    platform = feature("platform", box())
+    guide = feature("guide", box())
+
+    result = platform.union(guide).difference(box())
+
+    assert result.resolve() is None

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -29,6 +29,72 @@ def test_feature_registers_enabled_state_by_default():
     assert get_feature_states() == [FeatureState("lid", True)]
 
 
+def test_feature_default_sets_name_level_default_state():
+    from scadview.features import feature_default
+
+    feature_default("supports", enabled=False)
+
+    support_a = feature("supports", box())
+    support_b = feature("supports", box())
+
+    assert not support_a.enabled
+    assert not support_b.enabled
+    assert get_feature_states() == [FeatureState("supports", False)]
+
+
+def test_feature_default_uses_enabled_when_no_default_is_declared():
+    from scadview.features import feature_default
+
+    feature_default("supports", enabled=False)
+
+    lid = feature("lid", box())
+
+    assert lid.enabled
+    assert get_feature_states() == [FeatureState("lid", True)]
+
+
+def test_feature_default_does_not_override_controller_state():
+    from scadview.features import feature_default
+
+    set_enabled_feature_states({"supports": True})
+    feature_default("supports", enabled=False)
+
+    support = feature("supports", box())
+
+    assert support.enabled
+    assert get_feature_states() == [FeatureState("supports", True)]
+
+
+def test_feature_default_allows_idempotent_duplicate_declarations():
+    from scadview.features import feature_default
+
+    feature_default("supports", enabled=False)
+    feature_default("supports", enabled=False)
+
+    support = feature("supports", box())
+
+    assert not support.enabled
+
+
+def test_feature_default_rejects_conflicting_duplicate_declarations():
+    from scadview.features import feature_default
+
+    feature_default("supports", enabled=False)
+
+    with pytest.raises(ValueError, match="Conflicting default"):
+        feature_default("supports", enabled=True)
+
+
+def test_feature_default_is_available_from_top_level_api():
+    from scadview import feature_default
+
+    feature_default("supports", enabled=False)
+
+    support = feature("supports", box())
+
+    assert not support.enabled
+
+
 def test_feature_decorator_uses_function_name_by_default():
     @feature
     def lid():

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -2,10 +2,16 @@ from dataclasses import dataclass
 
 import pytest
 from manifold3d import Manifold
+from trimesh import Trimesh
 from trimesh.creation import box
 
 from scadview.features import (
+    _NATIVE_BOOLEAN_MEMBERS,
+    BooleanMesh,
     FeatureState,
+    NullFeatureMesh,
+    _native,
+    _patch_native_boolean_members,
     feature,
     get_feature_states,
     set_enabled_feature_states,
@@ -79,30 +85,35 @@ def test_feature_decorator_rejects_non_mesh_return_values():
         not_a_mesh()
 
 
-def test_disabled_feature_is_identity_for_trimesh_boolean_methods():
+def test_feature_call_rejects_non_mesh_values():
+    with pytest.raises(TypeError, match="feature mesh must be Trimesh or Manifold"):
+        feature("lid", "nope")
+
+
+def test_disabled_feature_has_side_aware_trimesh_boolean_methods():
     set_enabled_feature_states({"cutout": False})
     base = box()
     optional = feature("cutout", box())
 
     assert base.union(optional) is base
-    assert base.intersection(optional) is base
     assert base.difference(optional) is base
     assert optional.union(base) is base
-    assert optional.intersection(base) is base
-    assert optional.difference(base) is base
+    assert isinstance(base.intersection(optional), NullFeatureMesh)
+    assert isinstance(optional.intersection(base), NullFeatureMesh)
+    assert isinstance(optional.difference(base), NullFeatureMesh)
 
 
-def test_disabled_feature_is_identity_for_manifold_boolean_operators():
+def test_disabled_feature_has_side_aware_manifold_boolean_operators():
     set_enabled_feature_states({"cutout": False})
     base = Manifold.cube()
     optional = feature("cutout", Manifold.cube())
 
     assert (base + optional) is base
-    assert (base ^ optional) is base
     assert (base - optional) is base
     assert (optional + base) is base
-    assert (optional ^ base) is base
-    assert (optional - base) is base
+    assert isinstance(base ^ optional, NullFeatureMesh)
+    assert isinstance(optional ^ base, NullFeatureMesh)
+    assert isinstance(optional - base, NullFeatureMesh)
 
 
 def test_disabled_feature_chain_returns_null_feature_mesh():
@@ -112,4 +123,146 @@ def test_disabled_feature_chain_returns_null_feature_mesh():
 
     result = platform.union(guide).difference(box())
 
-    assert result.resolve() is None
+    assert result.is_empty()
+
+
+def test_boolean_mesh_operand_methods():
+    mesh = BooleanMesh(box())
+
+    assert mesh.as_operand() is mesh
+    assert not mesh.is_empty()
+    assert mesh.native() is not None
+
+
+def test_null_feature_mesh_operand_methods():
+    null_mesh = NullFeatureMesh()
+
+    assert null_mesh.as_operand() is null_mesh
+    assert null_mesh.is_empty()
+    assert null_mesh.union(NullFeatureMesh()) is null_mesh
+    assert null_mesh.difference(box()) is null_mesh
+    assert null_mesh.intersection(box()) is null_mesh
+    assert null_mesh + NullFeatureMesh() is null_mesh
+    assert null_mesh - box() is null_mesh
+    assert null_mesh ^ box() is null_mesh
+
+
+def test_enabled_trimesh_boolean_methods_delegate_to_native_methods(monkeypatch):
+    base = box()
+    other = box()
+    optional = feature("base", base)
+    calls: list[tuple[str, Trimesh]] = []
+
+    def union(self, operand):
+        calls.append(("union", operand))
+        return self
+
+    def difference(self, operand):
+        calls.append(("difference", operand))
+        return self
+
+    def intersection(self, operand):
+        calls.append(("intersection", operand))
+        return self
+
+    monkeypatch.setattr(Trimesh, "union", union)
+    monkeypatch.setattr(Trimesh, "difference", difference)
+    monkeypatch.setattr(Trimesh, "intersection", intersection)
+
+    assert optional.union(other) is base
+    assert optional.difference(feature("other", other)) is base
+    assert optional.intersection(BooleanMesh(other)) is base
+    assert calls == [
+        ("union", other),
+        ("difference", other),
+        ("intersection", other),
+    ]
+
+
+def test_enabled_manifold_boolean_operators_delegate_to_native_operators():
+    base = Manifold.cube()
+    other = Manifold.cube()
+    optional = feature("base", base)
+
+    assert isinstance(optional + other, Manifold)
+    assert isinstance(optional - feature("other", other), Manifold)
+    assert isinstance(optional ^ BooleanMesh(other), Manifold)
+
+
+def test_feature_mesh_reports_empty_state():
+    enabled = feature("enabled", box())
+    set_enabled_feature_states({"disabled": False})
+    disabled = feature("disabled", box())
+
+    assert not enabled.is_empty()
+    assert disabled.is_empty()
+
+
+def test_feature_mesh_delegates_attributes_and_wraps_native_method_results():
+    optional = feature("lid", box())
+
+    assert optional.vertices.shape[1] == 3
+    copied = optional.copy()
+    assert copied.name == "lid"
+    assert copied.enabled
+
+
+def test_feature_mesh_delegated_methods_return_non_mesh_values():
+    optional = feature("lid", box())
+
+    assert isinstance(optional.export(file_type="stl"), bytes)
+
+
+def test_feature_rejects_mesh_with_non_string_name():
+    with pytest.raises(TypeError, match="Expected feature name to be a string"):
+        feature(lambda: box(), box())
+
+
+def test_feature_rejects_invalid_argument():
+    with pytest.raises(TypeError, match="Expected feature"):
+        feature(123)
+
+
+def test_boolean_mesh_rejects_non_native_mesh():
+    with pytest.raises(TypeError, match="boolean mesh must be Trimesh or Manifold"):
+        BooleanMesh("nope")
+
+
+def test_mixed_backend_operations_raise_clear_type_errors():
+    trimesh_feature = feature("trimesh", box())
+    manifold_feature = feature("manifold", Manifold.cube())
+
+    with pytest.raises(TypeError, match="union requires Trimesh operands"):
+        trimesh_feature.union(manifold_feature)
+    with pytest.raises(TypeError, match="\\+ requires Manifold operands"):
+        manifold_feature + trimesh_feature
+    with pytest.raises(TypeError, match="\\+ requires Manifold operands"):
+        trimesh_feature + manifold_feature
+
+
+@pytest.mark.parametrize("method_name", ["union", "difference", "intersection"])
+def test_manifold_feature_rejects_trimesh_boolean_methods(method_name):
+    optional = feature("manifold", Manifold.cube())
+
+    with pytest.raises(AttributeError, match=f"has no attribute '{method_name}'"):
+        getattr(optional, method_name)(box())
+
+
+def test_native_rejects_null_operand():
+    with pytest.raises(TypeError, match="Expected non-empty boolean operand"):
+        _native(NullFeatureMesh())
+
+
+def test_patch_native_boolean_members_is_idempotent():
+    _patch_native_boolean_members()
+
+
+def test_patch_native_boolean_members_skips_missing_members():
+    class NativeWithoutBooleans:
+        pass
+
+    _NATIVE_BOOLEAN_MEMBERS[NativeWithoutBooleans] = ("missing",)
+    try:
+        _patch_native_boolean_members()
+    finally:
+        del _NATIVE_BOOLEAN_MEMBERS[NativeWithoutBooleans]

--- a/tests/test_mesh_loader_process.py
+++ b/tests/test_mesh_loader_process.py
@@ -5,6 +5,7 @@ import numpy.testing as npt
 import pytest
 from trimesh.creation import box, icosphere
 
+from scadview.features import FeatureState, feature
 from scadview.mesh_loader_process import (
     LoadResult,
     LoadStatus,
@@ -215,6 +216,30 @@ def test_load_worker_colors_mesh_list(load_queue):
     for tm in result.mesh:
         assert "scadview" in tm.metadata
         assert tm.metadata["scadview"]["color"][3] == 0.5
+
+
+def test_load_worker_tracks_feature_states_and_filters_disabled_features(load_queue):
+    with patch("scadview.mesh_loader_process.ModuleLoader") as mock_module_loader:
+        ml_instance = mock_module_loader.return_value
+
+        def _run_function(_module_path):
+            yield feature("cutout", box())
+
+        ml_instance.run_function.side_effect = _run_function
+        worker = LoadWorker(
+            "test/path",
+            load_queue,
+            feature_states={"cutout": False},
+        )
+        LoadWorker.load_number = 0
+        worker.load()
+
+    result = load_queue.get(timeout=1.0)
+    assert result.mesh is None
+    assert result.features == [FeatureState("cutout", False)]
+    result = load_queue.get(timeout=1.0)
+    assert result.complete
+    assert result.features == [FeatureState("cutout", False)]
 
 
 def test_load_worker_errors_on_nan_vertices(load_queue):


### PR DESCRIPTION
# SCADview Pull Request

---

## 📌 Summary

**Issue # (__required__):**  
Resolves #145

Add toggleable mesh features to loaded SCADview models so optional geometry can be enabled or disabled from the UI after a model is loaded.

---

## 🔍 Description of Changes

- add a `feature` API for mesh-returning functions and methods
- track feature state through the loader process and controller
- show discovered features in the wx UI and reload when toggled
- reject unsupported `@feature` usage on classes and non-mesh return values
- add targeted tests for feature behavior, controller reloads, and loader state propagation

## 🧪 Testing

- [ ] Not applicable

- Ran `.venv/bin/pytest tests/test_features.py tests/test_controller.py tests/test_mesh_loader_process.py`
- Ran `.venv/bin/ruff check src/scadview/features.py src/scadview/api/features.py src/scadview/__init__.py src/scadview/mesh_loader_process.py src/scadview/controller.py src/scadview/ui/wx/main_frame.py src/scadview/render/renderer.py tests/test_features.py tests/test_controller.py tests/test_mesh_loader_process.py`
- Ran `.venv/bin/ty check src/scadview/features.py src/scadview/api/features.py src/scadview/__init__.py src/scadview/mesh_loader_process.py src/scadview/controller.py src/scadview/ui/wx/main_frame.py src/scadview/render/renderer.py`

---

## 📝 Documentation

If your change affects public APIs or behavior:

- [x] I updated docstrings  
- [x] I updated or added relevant documentation in `/docs`  
- [ ] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [x] No  

---

## 🧠 Additional Notes

- Manual verification is still needed in the app UI for feature discovery and toggling behavior on real models.
- `CHANGELOG.md` was intentionally not edited because this repository uses release-please.

---

## ✔️ Checklist

Before requesting review, confirm the following:

- [x] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [x] I have run `mise preflight` and all stages pass
- [x] My changes include or update tests where appropriate.  
- [x] I have updated documentation where needed.  
- [x] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [x] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).