### PR TITLE
fix(ci): remove PAT dependency from release-please flow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,25 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_GH_PAT }}
+          token: ${{ github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish-release:
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    needs: release-please
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release.yml
+    with:
+      deploy_docs: true
+      publish: true
+      version: ${{ needs.release-please.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,22 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version without v prefix (e.g. 0.2.7)."
+        required: true
+        type: string
+      publish:
+        description: "Publish package to PyPI"
+        required: false
+        default: true
+        type: boolean
+      deploy_docs:
+        description: "Deploy docs to gh-pages with mike"
+        required: false
+        default: true
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
@@ -25,12 +39,12 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "release-${{ github.event.release.tag_name || github.ref_name }}"
+  group: "release-${{ inputs.version || github.ref_name }}"
   cancel-in-progress: false
 
 jobs:
   publish:
-    if: github.event_name == 'release' || inputs.publish
+    if: inputs.publish
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,11 +77,7 @@ jobs:
       - name: Resolve release version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          else
-            VERSION="${{ inputs.version }}"
-          fi
+          VERSION="${{ inputs.version }}"
           VERSION="${VERSION#v}"
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -88,8 +98,8 @@ jobs:
         run: uv publish --trusted-publishing=always
 
   docs:
-    if: (github.event_name == 'release' || (inputs.deploy_docs && inputs.version != '')) && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+    if: inputs.deploy_docs && inputs.version != '' && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     needs: publish
     uses: ./.github/workflows/docs.yml
     with:
-      version: ${{ inputs.version || github.event.release.tag_name }}
+      version: ${{ inputs.version }}


### PR DESCRIPTION
# SCADview Pull Request

---

## 📌 Summary

**Issue # (__required__):**  
Resolves #151

Remove the long-lived PAT requirement from the release pipeline so `release-please` can authenticate with the built-in GitHub Actions token and continue the publish flow without failing with `Bad credentials`.

---

## 🔍 Description of Changes

- Update `.github/workflows/release-please.yml` to use `${{ github.token }}` instead of `secrets.RELEASE_PLEASE_GH_PAT`.
- Capture `release_created` and `version` outputs from `googleapis/release-please-action@v4` and gate a follow-on publish job on those outputs.
- Convert `.github/workflows/release.yml` into a reusable workflow invoked from `release-please` rather than relying on a separate release-event trigger.

## 🧪 Testing

- [ ] Not applicable

- Ran `mise run actionlint`
- Confirmed the branch is clean after commit and push

---

## 📝 Documentation

If your change affects public APIs or behavior:

- [ ] I updated docstrings  
- [ ] I updated or added relevant documentation in `/docs`  
- [x] Not applicable  

---

## ⚠️ Breaking Changes

Does this PR introduce any breaking changes?

- [ ] Yes (explain below)  
- [x] No  

---

## 🧠 Additional Notes

- Root cause: the workflow depended on `RELEASE_PLEASE_GH_PAT`, so an invalid, expired, or insufficient PAT caused `googleapis/release-please-action@v4` to fail with `Bad credentials` before it could create or update the release PR.
- This changes the release pipeline topology slightly: publish/docs now run from the reusable `release.yml` workflow when `release-please` reports `release_created == true`, instead of depending on a second workflow triggered by a PAT-authenticated release event.

---

## ✔️ Checklist

Before requesting review, confirm the following:

- [x] The code follows SCADview's coding standards (PEP 8, type hints, etc.).  
- [x] I have run `mise preflight` and all stages pass
- [x] My changes include or update tests where appropriate.  
- [x] I have updated documentation where needed.  
- [x] I agree that my contributions are licensed under the **Apache-2.0 License**.
- [x] If merging, I will properly format the commit message for this PR to be compatible with [Release Please](https://github.com/googleapis/release-please), as documented in [CONTRIBUTING.md](./CONTRIBUTING.md).